### PR TITLE
fix(content-guards): strip CVE identifiers before year-blocking in webfetch-guard

### DIFF
--- a/content-guards/scripts/webfetch-guard.py
+++ b/content-guards/scripts/webfetch-guard.py
@@ -32,6 +32,11 @@ def main():
     )
     text_lower = text.lower()
 
+    # Strip well-known identifier patterns that legitimately contain years but
+    # are NOT year references (e.g. CVE-2025-43356, MS-2024-001).
+    # This prevents false-positive blocks on security advisories and similar IDs.
+    sanitized = re.sub(r"\bcve-\d{4}-\d+\b", "", text_lower, flags=re.IGNORECASE)
+
     now = datetime.now()
     current_year = now.year
     current_month = now.month
@@ -43,10 +48,10 @@ def main():
     else:
         blocked_years = [current_year - 1, current_year - 2]
 
-    # Find blocked year in text using word boundaries
+    # Find blocked year in sanitized text using word boundaries
     blocked_year = None
     for year in blocked_years:
-        if re.search(rf"\b{year}\b", text_lower):
+        if re.search(rf"\b{year}\b", sanitized):
             blocked_year = year
             break
 
@@ -69,8 +74,8 @@ def main():
         )
         return
 
-    # Warn if current year is referenced (using word boundaries)
-    if re.search(rf"\b{current_year}\b", text_lower):
+    # Warn if current year is referenced (using word boundaries, after CVE strip)
+    if re.search(rf"\b{current_year}\b", sanitized):
         date_str = now.strftime("%B %d, %Y")
         reason = (
             f"WARNING: You're searching with the current year ({current_year}).\n\n"

--- a/tests/content-guards/webfetch-guard/webfetch-guard.bats
+++ b/tests/content-guards/webfetch-guard/webfetch-guard.bats
@@ -1,4 +1,5 @@
 #!/usr/bin/env bats
+# cspell:ignore webfetch
 # Test suite for content-guards/scripts/webfetch-guard.py
 #
 # Tests tool name filtering, blocked year detection, and current year warnings.
@@ -101,4 +102,26 @@ run_hook() {
   run_hook '{"tool_name":"WebFetch","tool_input":{"url":"https://docs.python.org/3/","prompt":"explain decorators"}}'
   [ "$status" -eq 0 ]
   [ -z "$output" ]
+}
+
+# ---------------------------------------------------------------------------
+# TC8: CVE identifiers containing a blocked year are allowed (not year refs)
+# ---------------------------------------------------------------------------
+
+@test "TC8: WebSearch with CVE ID containing blocked year is allowed" {
+  run_hook '{"tool_name":"WebSearch","tool_input":{"query":"CVE-'"$BLOCKED_YEAR"'-43356 vulnerability details"}}'
+  [ "$status" -eq 0 ]
+  [[ ! "$output" =~ "deny" ]]
+}
+
+@test "TC8b: WebFetch NVD URL containing CVE ID with blocked year is allowed" {
+  run_hook '{"tool_name":"WebFetch","tool_input":{"url":"https://nvd.nist.gov/vuln/detail/CVE-'"$BLOCKED_YEAR"'-43356","prompt":"extract severity"}}'
+  [ "$status" -eq 0 ]
+  [[ ! "$output" =~ "deny" ]]
+}
+
+@test "TC8c: WebSearch with multiple CVE IDs containing blocked year is allowed" {
+  run_hook '{"tool_name":"WebSearch","tool_input":{"query":"CVE-'"$BLOCKED_YEAR"'-43356 CVE-'"$BLOCKED_YEAR"'-47183 security advisory"}}'
+  [ "$status" -eq 0 ]
+  [[ ! "$output" =~ "deny" ]]
 }


### PR DESCRIPTION
## Summary

- Strip CVE identifier patterns (e.g. `CVE-2025-43356`) from search/fetch text before applying the year-blocking check in `webfetch-guard.py`
- Prevents false-positive blocks when fetching security advisories, NVD entries, or any URL/query containing a CVE ID whose embedded year falls in the blocked-year window
- Adds three bats test cases (TC8/TC8b/TC8c) to cover WebSearch and WebFetch with CVE IDs

## Test plan

- [ ] `bats tests/content-guards/webfetch-guard/webfetch-guard.bats` — all tests pass including new TC8/TC8b/TC8c
- [ ] WebSearch for `CVE-2024-43356 vulnerability` is allowed (not blocked or warned)
- [ ] WebFetch of `https://nvd.nist.gov/vuln/detail/CVE-2024-43356` is allowed
- [ ] Existing year-blocking behavior unchanged for non-CVE year references

🤖 Generated with [Claude Code](https://claude.com/claude-code)