### PR TITLE
fix(ai-delegation,github-workflows): align with PAL policy and fix refs

### DIFF
--- a/ai-delegation/skills/auto-maintain/SKILL.md
+++ b/ai-delegation/skills/auto-maintain/SKILL.md
@@ -29,9 +29,9 @@ gh pr list --author @me --state open --json number | jq length
 1. SCAN - Gather state (PR-focus: only PRs; Normal: all)
 2. PRIORITIZE:
    1. PRs behind main (/sync-main)
-   2. Failing CI (/fix-pr-ci)
-   3. Review comments (/resolve-pr-review-thread)
-   4. PRs ready to merge (/git-refresh) - Report readiness, do NOT merge
+   2. Failing CI (/finalize-pr)
+   3. Review comments (/resolve-pr-threads)
+   4. PRs ready to merge (/refresh-repo) - Report readiness, do NOT merge
    --- BLOCKED IN PR-FOCUS MODE ---
    5-10. Bugs, issues, code analysis, docs, tests, deps
 3. DISPATCH - Use subagents (parallel in PR-focus, sequential otherwise; invoke `superpowers:dispatching-parallel-agents`)

--- a/ai-delegation/skills/delegate-to-ai/SKILL.md
+++ b/ai-delegation/skills/delegate-to-ai/SKILL.md
@@ -1,52 +1,53 @@
 ---
 name: delegate-to-ai
-description: Route tasks to external AI models via PAL MCP tools
+description: Route tasks to external AI models via Bifrost and PAL MCP multi-model tools
 ---
 
 # Delegate to External AI
 
-Routes tasks to specialized models based on task type and constraints using PAL MCP tools.
+Routes tasks to specialized models based on task type using Bifrost (single-model) or PAL MCP (multi-model).
 
 ## When to Delegate
 
 Delegate when Claude is not the best tool:
 
-- **Large context** (1M+ tokens) -> Gemini 3 Pro via PAL `chat` tool
-- **Math/reasoning** -> DeepSeek R1 via PAL `chat` tool
-- **Private/offline** -> Local Ollama via PAL `chat` tool
-- **Code review consensus** -> Multi-model via PAL `consensus` tool
-- **Architecture planning** -> Claude Opus or Gemini via PAL `planner` tool
+- **Large context** (1M+ tokens) -> Gemini 3 Pro via Bifrost
+- **Math/reasoning** -> DeepSeek R1 via Bifrost
+- **Private/offline** -> Local MLX via Bifrost (port 30080 routes to local MLX server)
+- **Code review consensus** -> Multi-model via PAL `consensus`
+- **Parallel multi-model research** -> PAL `clink` (when you need multiple model perspectives simultaneously)
+- **Architecture planning** -> Claude Opus native subagent (Plan mode or `Plan` subagent type)
 
-## PAL MCP Tools
+## Route Selection
 
-- **`chat`** - Single model for straightforward tasks
+| Task Type | Cloud Model | Local Model | Route |
+| --- | --- | --- | --- |
+| Research (single) | Gemini 3 Pro | mlx-community/Qwen3-235B-A22B-4bit | Bifrost |
+| Research (multi) | Multiple | mlx-community/Qwen3-235B-A22B-4bit | PAL clink |
+| Complex Coding | Claude Opus | mlx-community/Qwen3.5-122B-A10B-4bit | native subagent |
+| Fast Tasks | Claude Sonnet | mlx-community/Qwen3.5-27B-4bit | Bifrost |
+| Code Review | Multi-model | mlx-community/Qwen3.5-27B-4bit | PAL consensus |
+| Architecture | Claude Opus | mlx-community/Qwen3-235B-A22B-4bit | native subagent |
+
+**Bifrost endpoint**: `http://localhost:30080/v1/chat/completions` (OpenAI-compatible)
+
+## PAL MCP Tools (multi-model only)
+
 - **`clink`** - Parallel queries across multiple models
 - **`consensus`** - Multi-model agreement for critical decisions
-- **`codereview`** - Structured code review with multiple perspectives
-- **`planner`** - Architecture and design planning
-- **`precommit`** - Quick validation before committing
+
+All other PAL tools have native Claude Code equivalents — use Bifrost or native subagents instead.
 
 ## Workflow
 
-1. **Identify task type** (research, coding, review, architecture, planning)
-2. **Select PAL MCP tool** based on type and constraints
-3. **Execute via Task tool** with appropriate agent subtype
+1. **Identify task type** (research, coding, review, architecture)
+2. **Select route**: Bifrost for single-model, PAL for multi-model, native subagent for implementation work
+3. **Execute**: Bifrost via `curl`/Bash; PAL via MCP tool call; native subagent via Agent tool
 4. **Synthesize results** if using multi-model tools
-
-## Model Routing
-
-| Task Type | Cloud Model | Local Model | PAL Tool |
-| --- | --- | --- | --- |
-| Research | Gemini 3 Pro | qwen3-next:80b | `chat`, `clink` |
-| Complex Coding | Claude Opus | qwen3-coder:30b | `codereview` |
-| Fast Tasks | Claude Sonnet | qwen3-next:latest | `chat` |
-| Code Review | Multi-model | deepseek-r1:70b | `consensus` |
-| Architecture | Claude Opus | qwen3-next:80b | `planner` |
 
 ## Local-Only Mode
 
-When `localOnlyMode` is enabled or `--local` flag is passed, all tasks route to Ollama models.
-No cloud API calls are made.
+When `localOnlyMode` is enabled or `--local` flag is passed, route all tasks through Bifrost to the local MLX inference server. No cloud API calls are made.
 
 ## Related Skills
 

--- a/ai-delegation/skills/delegate-to-ai/SKILL.md
+++ b/ai-delegation/skills/delegate-to-ai/SKILL.md
@@ -23,13 +23,15 @@ Delegate when Claude is not the best tool:
 | Task Type | Cloud Model | Local Model | Route |
 | --- | --- | --- | --- |
 | Research (single) | Gemini 3 Pro | mlx-community/Qwen3-235B-A22B-4bit | Bifrost |
-| Research (multi) | Multiple | mlx-community/Qwen3-235B-A22B-4bit | PAL clink |
+| Research (multi) | Multiple | mlx-community/Qwen3-235B-A22B-4bit¹ | PAL clink |
 | Complex Coding | Claude Opus | mlx-community/Qwen3.5-122B-A10B-4bit | native subagent |
 | Fast Tasks | Claude Sonnet | mlx-community/Qwen3.5-27B-4bit | Bifrost |
 | Code Review | Multi-model | mlx-community/Qwen3.5-27B-4bit | PAL consensus |
 | Architecture | Claude Opus | mlx-community/Qwen3-235B-A22B-4bit | native subagent |
 
 **Bifrost endpoint**: `http://localhost:30080/v1/chat/completions` (OpenAI-compatible)
+
+¹ In local-only mode, `PAL clink` (multi-model) falls back to this single best local model.
 
 ## PAL MCP Tools (multi-model only)
 
@@ -47,7 +49,8 @@ All other PAL tools have native Claude Code equivalents — use Bifrost or nativ
 
 ## Local-Only Mode
 
-When `localOnlyMode` is enabled or `--local` flag is passed, route all tasks through Bifrost to the local MLX inference server. No cloud API calls are made.
+When `localOnlyMode` is enabled or `--local` flag is passed, route all tasks through
+Bifrost to the local MLX inference server (overrides native subagent rows). No cloud API calls are made.
 
 ## Related Skills
 

--- a/github-workflows/skills/shape-issues/SKILL.md
+++ b/github-workflows/skills/shape-issues/SKILL.md
@@ -3,6 +3,8 @@ name: shape-issues
 description: Shape raw ideas into actionable GitHub Issues using Shape Up methodology
 ---
 
+<!-- cspell:ignore roksechs timebox -->
+
 # Shape Issues
 
 Iterative issue exploration and shaping process that transforms rough ideas into well-defined,
@@ -16,7 +18,7 @@ time-boxed GitHub Issues using Shape Up methodology and continuous discovery pri
 2. **Solution Sketching**: Brainstorm approaches, set scope boundaries, identify risks
 3. **Issue Formation**: Problem statement, timebox, solution sketch, rabbit holes
 4. **Betting Table**: Prioritize by timebox, balance portfolio, set circuit breakers
-5. **Issue Crafting**: Create GitHub Issues with size labels, handoff to `/resolve-issues`
+5. **Issue Crafting**: Create GitHub Issues with size labels, add `ready-for-dev` label for developer pickup
 
 ## Sizing
 
@@ -47,7 +49,7 @@ Rabbit Holes (complexity traps), Done Looks Like (acceptance criteria).
 /shape-issues
 ```
 
-**Workflow**: `/shape-issues` -> `/resolve-issues` -> `/review-pr` -> `/resolve-pr-review-thread`
+**Workflow**: `/shape-issues` -> implementation -> `/ship`
 
 ## Related Skills
 


### PR DESCRIPTION
# PR #230: Align skills with PAL policy and fix cross-references

## Summary

Aligns 3 skills with current PAL MCP policy and Opus 4.7+ cloud stack.
Removes deprecated PAL tools, fixes broken cross-references, and clarifies
local-only fallback modes.

**Key changes:**

- **`delegate-to-ai`**: Remove 4 deprecated PAL tools (chat, code review,
  planner, precommit). Route single-model calls via Bifrost. Update local model
  names from Ollama aliases to MLX aliases. Add Research (multi) row for PAL
  clink. Clarify execution method per route.
- **`auto-maintain`**: Fix 3 broken skill refs: /fix-pr-ci → /finalize-pr,
  /resolve-pr-review-thread → /resolve-pr-threads, /git-refresh → /refresh-repo
- **`shape-issues`**: Remove non-existent /resolve-issues handoff; fix workflow
  chain (dropped redundant /resolve-pr-threads — /ship already invokes it via
  /finalize-pr)

## Test plan

- [ ] agent skills validate passes for all 3 changed skills
- [ ] No remaining grep matches for /fix-pr-ci, /git-refresh,
  /resolve-pr-review-thread, /resolve-issues
- [ ] delegate-to-ai routing table matches ~/CLAUDE.md model routing rules
- [ ] auto-maintain core loop priority list references valid, existing skills

Generated with [Claude Code](https://claude.com/claude-code)
