### PR TITLE
fix(github-workflows): replace --body-file temp files with inline heredoc

### DIFF
--- a/cspell.json
+++ b/cspell.json
@@ -22,6 +22,7 @@
     "mvexpand",
     "mvfilter",
     "nullglob",
+    "oneline",
     "pids",
     "recognises",
     "reinvocation",

--- a/github-workflows/skills/finalize-pr/SKILL.md
+++ b/github-workflows/skills/finalize-pr/SKILL.md
@@ -177,8 +177,16 @@ Steps 4.1 and 4.2 run sequentially within the agent. Step 4.3 runs after both.
 
 ### 4.3 Apply Updates
 
-After 4.1 and 4.2 complete, write the body to a temp file and apply with `gh pr edit --body-file`
-(safer than inline for multiline content).
+After 4.1 and 4.2 complete, apply directly — no temp files:
+
+```bash
+gh pr edit {number} --body "$(cat <<'EOF'
+... generated body ...
+EOF
+)"
+```
+
+Single-quoted `'EOF'` prevents shell expansion. Closing `EOF` must be alone on its own line with no leading whitespace.
 
 Proceed to Phase 5.
 

--- a/github-workflows/skills/finalize-pr/SKILL.md
+++ b/github-workflows/skills/finalize-pr/SKILL.md
@@ -177,10 +177,10 @@ Steps 4.1 and 4.2 run sequentially within the agent. Step 4.3 runs after both.
 
 ### 4.3 Apply Updates
 
-After 4.1 and 4.2 complete, apply directly — no temp files:
+After 4.1 and 4.2 complete, apply title and body together — no temp files:
 
 ```bash
-gh pr edit {number} --body "$(cat <<'EOF'
+gh pr edit {number} --title "generated title" --body "$(cat <<'EOF'
 ... generated body ...
 EOF
 )"

--- a/github-workflows/skills/squash-merge-pr/SKILL.md
+++ b/github-workflows/skills/squash-merge-pr/SKILL.md
@@ -48,15 +48,11 @@ Generate:
 
 Types: `feat`, `fix`, `refactor`, `docs`, `test`, `chore`
 
-Store the title in a shell variable and write the body to a temp file using the Write tool
-(avoids shell quoting issues with multi-line text):
+Store the title in a shell variable:
 
 ```bash
 SQUASH_TITLE="<generated title>"
-SQUASH_BODY_FILE=$(mktemp)
 ```
-
-Use the Write tool to write the generated body text to the path stored in `$SQUASH_BODY_FILE`.
 
 ## Step 3: Execute Squash Merge
 
@@ -66,12 +62,17 @@ Capture the branch name before merging (needed for cleanup):
 BRANCH=$(gh pr view {pr} --json headRefName --jq '.headRefName')
 ```
 
-Merge without `--delete-branch` (avoids `git switch` failure in bare+worktree repos):
+Merge without `--delete-branch` (avoids `git switch` failure in bare+worktree repos).
+Use a heredoc for the body — no temp files:
 
 ```bash
-gh pr merge {pr} --squash --subject "$SQUASH_TITLE" --body-file "$SQUASH_BODY_FILE"
-rm -f "$SQUASH_BODY_FILE"
+gh pr merge {pr} --squash --subject "$SQUASH_TITLE" --body "$(cat <<'EOF'
+... generated body ...
+EOF
+)"
 ```
+
+Single-quoted `'EOF'` prevents shell expansion. Closing `EOF` must be alone on its own line with no leading whitespace.
 
 Delete the remote branch (GitHub may have auto-deleted it on merge — `|| true` handles that):
 

--- a/tests/content-guards/enforce-issue-limits/enforce-issue-limits.bats
+++ b/tests/content-guards/enforce-issue-limits/enforce-issue-limits.bats
@@ -163,12 +163,12 @@ run_hook() {
   [ "$status" -eq 0 ]
 }
 
-@test "TC7b: gh pr edit with --body-file is always allowed" {
+@test "TC7b: gh pr edit with --body is always allowed" {
   local now
   now="$(utc_now)"
   export GH_RESPONSE="$(build_json_array '{"createdAt":"'"$now"'"}' 25)"
 
-  run_hook '{"tool_input":{"command":"gh pr edit 126 --body-file /tmp/pr-body.md"}}'
+  run_hook '{"tool_input":{"command":"gh pr edit 126 --body \"updated description\""}}'
   [ "$status" -eq 0 ]
 }
 


### PR DESCRIPTION
## Summary

Eliminates unnecessary temporary file handling in two skill files by using inline heredoc patterns instead of the `--body-file` flag. This simplifies the workflow and reduces intermediate I/O operations.

**Changes:**
- `finalize-pr/SKILL.md` Phase 4.3: Replaced `mktemp` + Write tool + `--body-file` with `gh pr edit --body "$(cat <<'EOF2' ... EOF2)"`
- `squash-merge-pr/SKILL.md`: Removed full temp file lifecycle; merge command now uses the same inline heredoc pattern
- `finalize-pr/SKILL.md` follow-up: Added `--title` flag to Phase 4.3 (applies title alongside body in single edit call)
- `enforce-issue-limits.bats` TC7b: Updated test to reflect `--body` usage (hook behavior unchanged)
- `cspell.json`: Added `oneline` to fix spell-check failure on `git log --oneline`

## Test Plan

- All 23 bats tests pass: `bats tests/content-guards/enforce-issue-limits/enforce-issue-limits.bats`
- No `--body-file` or `mktemp` remaining in any skill `.md` files
- All pre-commit hooks pass (markdown lint, spell check, skill validation)

🤖 Generated with [Claude Code](https://claude.com/claude-code)