### PR TITLE
fix(git-workflows): make refresh tag cleanup safe

### DIFF
--- a/.claude/rules/worktree-conventions.md
+++ b/.claude/rules/worktree-conventions.md
@@ -27,11 +27,11 @@ Examples:
 ## Before Creating
 
 1. Switch to main and sync: `cd ~/git/{repo-name}/main && git switch main && git pull`
-2. Clean stale worktrees (merged PRs or `[gone]` remote branches):
-   - `gh pr list --state merged --head {branch}` to confirm PR was merged
-   - `git branch -vv | grep '\[gone\]'` to find deleted remote branches
+2. Clean stale worktrees — a worktree is stale when it has no open PR, no uncommitted changes, and either:
+   - A merged PR whose `headRefOid` matches local `HEAD` (`gh pr list --state merged --head {branch} --json number,headRefOid,mergedAt`)
+   - A deleted remote (`[gone]` in `git branch -vv`) with no commits ahead of default
    - `git worktree remove {path}` (never `--force`) + `git branch -d {branch}`
-   - If `git branch -d` fails (branch not merged locally, e.g. squash-merge), investigate before using `git branch -D`
+   - If `git branch -d` fails on a squash-merged branch, use `git branch -D` only when the merged PR `headRefOid` matched local `HEAD`
    - `git worktree prune` to clean up
 
 ## After Creating

--- a/git-standards/skills/git-workflow-standards/SKILL.md
+++ b/git-standards/skills/git-workflow-standards/SKILL.md
@@ -35,11 +35,12 @@ Remove: `git worktree remove ~/git/<repo>/<branch>`
 Every branch with commits MUST have an associated PR.
 Orphaned branches must get a PR or be deleted.
 
-**Stale worktree**: A branch with a deleted remote (`[gone]`), or a merged PR
-(`gh pr list --state merged --head <branch>`) with no commits ahead of the default branch
-(`git log origin/main..HEAD --oneline` is empty). Branches with open PRs, local-only
-branches without merged PRs, and worktrees with uncommitted changes are NEVER stale.
-Use `git worktree remove` (never `--force`) — Git natively blocks removal of dirty worktrees.
+**Stale worktree**: A branch with no open PR, no uncommitted changes, and either a merged PR
+whose `headRefOid` matches local `HEAD`, or a deleted remote (`[gone]`) with no commits ahead
+of the default branch (`git log origin/<default>..HEAD --oneline` is empty). Branches with open
+PRs, local-only branches without merged PRs, local commits beyond the merged PR head, and
+worktrees with uncommitted changes are NEVER stale. Use `git worktree remove` (never `--force`)
+— Git natively blocks removal of dirty worktrees.
 
 ## Branch Hygiene
 

--- a/git-workflows/skills/refresh-repo/SKILL.md
+++ b/git-workflows/skills/refresh-repo/SKILL.md
@@ -37,45 +37,85 @@ gh pr view NUMBER --json state,mergeable,statusCheckRollup,reviewDecision
 
 ### 3. Sync Workflow
 
-1. Fetch all remotes and prune deleted remote branches
-2. Switch to default branch (main or master)
-3. Pull latest changes
-4. Delete local branches already merged into default (never delete main/master/develop)
-5. Switch back to original branch if it still exists
+1. Record the current branch and worktree path.
+2. Fetch origin with stale remote branch pruning, but without tag updates:
+   `git fetch origin --no-tags --prune --force`
+3. Determine the default branch from `origin/HEAD`, falling back to `main` or `master`.
+4. Sync the default branch from its existing worktree with a fast-forward only merge:
+   `git merge --ff-only origin/<default>`.
+   If the default worktree is dirty or divergent, report it and skip instead of resetting.
+5. Delete local branches already merged into the default branch with `git branch -d`.
+   Never delete main/master/develop/current branches, worktree-checked-out branches, or branches
+   with open PRs.
+6. Switch back to the original branch if it still exists.
 
-### 4. Worktree Cleanup
+Do not use `git fetch --tags`, `git fetch --prune-tags`, or `git pull --tags` during the
+normal refresh. Tags are audited separately in Step 4 so local-only non-release tags and
+tag rewrites are not deleted by a broad fetch refspec.
+
+### 4. Tag Audit And Cleanup
+
+Treat `origin` as authoritative for release tags only.
+
+Use native Git commands to compare local tags to remote tags:
+
+```bash
+git for-each-ref '--format=%(refname:short)' refs/tags
+git show-ref --tags
+git ls-remote --tags --refs origin
+```
+
+For local-only tags:
+
+1. If the tag name matches the release tag pattern `v[0-9]*`, delete it with
+   `git tag -d <tag>`.
+2. If the tag name does not match the release tag pattern, report it and do not delete it.
+
+For tags that exist both locally and on origin but point at different objects, report the
+mismatch and do not force-update it automatically. Never delete or rewrite remote tags.
+
+### 5. Worktree Cleanup
 
 Only remove a worktree if it is confirmed stale.
 
-**Stale definition**: The branch has a merged PR (`gh pr list --state merged --head <branch>`)
-OR its remote tracking branch was deleted (`[gone]` in `git branch -vv`).
+**Stale definition**: No open PR, no uncommitted changes, and either:
+
+- The branch has a merged PR whose `headRefOid` matches the local branch `HEAD`
+  (`gh pr list --state merged --head <branch> --json number,headRefOid,mergedAt`)
+- Its remote tracking branch was deleted (`[gone]` in `git branch -vv`) and it has no commits
+  ahead of the default branch (`git log origin/<default>..HEAD --oneline` is empty)
 
 Branches with open PRs, local-only branches without PRs, and worktrees with uncommitted
 changes are **NEVER** stale.
 
 For each worktree from `git worktree list`:
 
-1. Skip the default branch (main/master) and bare repo entries
+1. Skip the default branch (main/master), the current branch, and bare repo entries
 2. If the branch has an open PR, skip — it is **never** stale
-3. Check if stale: `[gone]` remote, or merged PR (`gh pr list --state merged --head <branch>`)
-   AND no commits ahead of default (`git log origin/main..HEAD --oneline` is empty)
+3. Check if stale using the definition above
 4. If not stale, skip
 5. Run `git worktree remove <path>` — **NEVER use `--force`**
 6. If Git blocks removal (dirty worktree), report it and skip
 7. If removed, also delete the branch: `git branch -d <branch>`.
-   If this fails (squash-merged branch not reachable from local main), investigate before using `git branch -D`
+   If this fails only because a squash-merged branch is not reachable from local default,
+   use `git branch -D <branch>` only when the merged PR `headRefOid` matched the local
+   branch `HEAD` before removing the worktree.
 
 Finish with `git worktree prune`.
 
-### 5. Summary
+### 6. Summary
 
-Report: PRs assessed as merge-ready (if any), branches cleaned up, worktrees removed, current branch and sync status.
+Report: PRs assessed as merge-ready (if any), tags deleted or reported, branches cleaned up,
+worktrees removed, current branch, and sync status.
 
 ## Common Mistake to Avoid
 
 **DO NOT** skip the PR check just because you're on main. The user may have multiple open PRs from different branches.
 
 Always run `gh pr list --author @me --state open` to find work that needs merging.
+
+Do not use `--prune-tags` as a shortcut for tag cleanup. Git treats tag pruning as an
+explicit refspec prune and can delete local-only tags that are not release artifacts.
 
 ## Related Skills
 

--- a/git-workflows/skills/refresh-repo/SKILL.md
+++ b/git-workflows/skills/refresh-repo/SKILL.md
@@ -3,6 +3,8 @@ name: refresh-repo
 description: Check PR merge readiness, sync local repo, and cleanup stale worktrees
 ---
 
+<!-- cspell:words refspec oneline headRefOid mergedAt -->
+
 # Git Refresh
 
 Check open PR merge-readiness status, sync the local repository, and cleanup stale worktrees.
@@ -80,7 +82,7 @@ Only remove a worktree if it is confirmed stale.
 
 **Stale definition**: No open PR, no uncommitted changes, and either:
 
-- The branch has a merged PR whose `headRefOid` matches the local branch `HEAD`
+- The branch has a merged PR (most recently merged by `mergedAt`) whose `headRefOid` matches the local branch `HEAD`
   (`gh pr list --state merged --head <branch> --json number,headRefOid,mergedAt`)
 - Its remote tracking branch was deleted (`[gone]` in `git branch -vv`) and it has no commits
   ahead of the default branch (`git log origin/<default>..HEAD --oneline` is empty)
@@ -90,7 +92,7 @@ changes are **NEVER** stale.
 
 For each worktree from `git worktree list`:
 
-1. Skip the default branch (main/master), the current branch, and bare repo entries
+1. Skip the default branch worktree, the current branch, and bare repo entries
 2. If the branch has an open PR, skip — it is **never** stale
 3. Check if stale using the definition above
 4. If not stale, skip


### PR DESCRIPTION
## Summary

- Update /refresh-repo to fetch with `git fetch origin --no-tags --prune --force` by default
- Add a separate tag audit that deletes only local-only release-style tags and reports other tag drift
- Refine stale worktree cleanup to handle squash-merged PR branches only when the merged PR head matches local HEAD
- Align git workflow standards with the updated stale worktree definition

## Test Plan

- `markdownlint-cli2 git-workflows/skills/refresh-repo/SKILL.md git-standards/skills/git-workflow-standards/SKILL.md`
- `pre-commit run --files git-workflows/skills/refresh-repo/SKILL.md git-standards/skills/git-workflow-standards/SKILL.md`
- `git diff --check`

## Notes

- `./scripts/run-tests.sh` reported no test files found in this repo layout
- Direct `bats tests` could not run locally because `bats` is not installed