### PR TITLE
fix(content-guards): bound validate-markdown parent-walk at repo / $HOME

### DIFF
--- a/.github/workflows/validate-plugin.yml
+++ b/.github/workflows/validate-plugin.yml
@@ -109,8 +109,8 @@ jobs:
             jq empty "$json_file"
           done
 
-      - name: Install bats-core
-        run: sudo npm install -g bats
+      - name: Install bats-core and markdownlint-cli2
+        run: sudo npm install -g bats markdownlint-cli2
 
       - name: Run tests
         run: |

--- a/content-guards/scripts/validate-markdown.sh
+++ b/content-guards/scripts/validate-markdown.sh
@@ -58,11 +58,19 @@ if command -v markdownlint-cli2 &>/dev/null; then
   # Check for project-level markdownlint config (walk up from file's directory)
   search_dir="$(dirname -- "$file_path")"
   while true; do
+    # $HOME and / are user/system scope, not project scope — check before scanning
+    if [[ "$search_dir" == "$HOME" || "$search_dir" == "/" ]]; then
+      break
+    fi
     shopt -s nullglob
     config_files=("$search_dir"/.markdownlint*)
     shopt -u nullglob
     if ((${#config_files[@]} > 0)); then
       has_project_config=true
+      break
+    fi
+    # Stop at project root after checking for config there
+    if [[ -d "$search_dir/.git" ]]; then
       break
     fi
     parent_dir="$(dirname -- "$search_dir")"
@@ -78,7 +86,7 @@ if command -v markdownlint-cli2 &>/dev/null; then
     config_flag=(--config "$HOME/.markdownlint-cli2.yaml")
   else
     # Use plugin default config if available, otherwise create temporary fallback
-    plugin_config="${CLAUDE_PLUGIN_ROOT}/config/.markdownlint-cli2.yaml"
+    plugin_config="${CLAUDE_PLUGIN_ROOT:-}/config/.markdownlint-cli2.yaml"
 
     if [[ -n "${CLAUDE_PLUGIN_ROOT:-}" ]] && [[ -f "$plugin_config" ]]; then
       # Plugin config exists and is readable

--- a/content-guards/scripts/validate-markdown.sh
+++ b/content-guards/scripts/validate-markdown.sh
@@ -59,7 +59,7 @@ if command -v markdownlint-cli2 &>/dev/null; then
   search_dir="$(dirname -- "$file_path")"
   while true; do
     # $HOME and / are user/system scope, not project scope — check before scanning
-    if [[ "$search_dir" == "$HOME" || "$search_dir" == "/" ]]; then
+    if [[ "$search_dir" == "${HOME:-}" || "$search_dir" == "/" ]]; then
       break
     fi
     shopt -s nullglob
@@ -70,7 +70,7 @@ if command -v markdownlint-cli2 &>/dev/null; then
       break
     fi
     # Stop at project root after checking for config there
-    if [[ -d "$search_dir/.git" ]]; then
+    if [[ -e "$search_dir/.git" ]]; then
       break
     fi
     parent_dir="$(dirname -- "$search_dir")"

--- a/tests/content-guards/markdown-validator/validate-markdown.bats
+++ b/tests/content-guards/markdown-validator/validate-markdown.bats
@@ -92,13 +92,17 @@ setup() {
   # parse it → script exits 2. If the fix is correct, the walk stops at $HOME,
   # falls back to the inline temp config, and the valid doc.md lints cleanly → exit 0.
 
+  local fake_home
   fake_home=$(mktemp -d)
+  # Ensure cleanup even on assertion failure
+  trap 'rm -rf "$fake_home"' EXIT
+
   # Broken config that markdownlint-cli2 cannot parse — if picked up, causes failure
   printf 'NOT_VALID_JSON_OR_YAML -- TC9 HOME boundary sentinel' \
     > "$fake_home/.markdownlint-cli2.jsonc"
 
   # Project dir inside fake HOME: no .git, no .markdownlint*
-  project_dir="$fake_home/myproject"
+  local project_dir="$fake_home/myproject"
   mkdir -p "$project_dir"
   printf '# Hello\n' > "$project_dir/doc.md"
 
@@ -108,6 +112,4 @@ setup() {
 
   # Correct: walk stopped at $HOME, used inline config, lint passed
   [ "$status" -eq 0 ]
-
-  rm -rf "$fake_home"
 }

--- a/tests/content-guards/markdown-validator/validate-markdown.bats
+++ b/tests/content-guards/markdown-validator/validate-markdown.bats
@@ -6,6 +6,7 @@
 # - Config resolution (project vs fallback)
 # - Cross-repo editing scenarios
 # - Unbound variable regression (PR #39, #40)
+# - HOME boundary walk regression (TC9)
 #
 # Run with: bats tests/content-guards/markdown-validator/validate-markdown.bats
 
@@ -78,4 +79,35 @@ setup() {
   run bash -c 'echo "{}" | /bin/bash "$1"' _ "$SCRIPT"
   [ "$status" -eq 0 ]
   [ -z "$output" ]
+}
+
+@test "TC9: parent walk stops before HOME — does not pick up ~/.markdownlint* and OOM" {
+  # Regression for: walk climbs past project root into $HOME, finds
+  # ~/.markdownlint-cli2.jsonc (Nix home-manager symlink), cd $HOME, OOM.
+  # Fix: $HOME and / are checked before config scan so user-level configs
+  # are never treated as project configs.
+  #
+  # Strategy: put intentionally-broken JSON in fake $HOME/.markdownlint-cli2.jsonc.
+  # If the walk incorrectly picks it up (old bug), markdownlint-cli2 fails to
+  # parse it → script exits 2. If the fix is correct, the walk stops at $HOME,
+  # falls back to the inline temp config, and the valid doc.md lints cleanly → exit 0.
+
+  fake_home=$(mktemp -d)
+  # Broken config that markdownlint-cli2 cannot parse — if picked up, causes failure
+  printf 'NOT_VALID_JSON_OR_YAML -- TC9 HOME boundary sentinel' \
+    > "$fake_home/.markdownlint-cli2.jsonc"
+
+  # Project dir inside fake HOME: no .git, no .markdownlint*
+  project_dir="$fake_home/myproject"
+  mkdir -p "$project_dir"
+  printf '# Hello\n' > "$project_dir/doc.md"
+
+  run env HOME="$fake_home" bash -c \
+    'echo "{\"tool_input\":{\"file_path\":\"'"$project_dir/doc.md"'\"}}" | /bin/bash "$1"' \
+    _ "$SCRIPT"
+
+  # Correct: walk stopped at $HOME, used inline config, lint passed
+  [ "$status" -eq 0 ]
+
+  rm -rf "$fake_home"
 }


### PR DESCRIPTION
## Summary

- **Walk boundary**: The parent-walk loop now checks `$HOME` and `/` _before_ scanning for `.markdownlint*` configs, preventing user-level home configs (e.g. a Nix home-manager `~/.markdownlint-cli2.jsonc`) from being picked up as project configs.
- **OOM root cause**: When the old code found `~/.markdownlint-cli2.jsonc`, it set `lint_dir=$HOME` and ran `cd $HOME && markdownlint-cli2 <file>` — causing globby to enumerate the entire home directory tree, OOMing Node.
- **CLAUDE_PLUGIN_ROOT unbound variable**: Fixed a latent `set -u` crash on the `plugin_config` assignment when `CLAUDE_PLUGIN_ROOT` is not set and no project or home config is found.
- **Regression test TC9**: Adds a bats test that places a broken-JSON config at a fake `$HOME` — if the walk incorrectly picks it up markdownlint-cli2 exits non-zero; the correct path uses inline temp config and exits 0.

## Test plan

- [ ] `bats tests/content-guards/markdown-validator/validate-markdown.bats` — all 9 tests pass locally
- [ ] CI green on this PR
- [ ] Verify TC9 would have failed against the pre-fix script (old code picks up broken home config → exit 2)

🤖 Generated with [Claude Code](https://claude.com/claude-code)