### PR TITLE
fix(git-guards): support GIT_GUARD_BRANCH_OVERRIDE for testing

### DIFF
--- a/git-guards/scripts/git-permission-guard.py
+++ b/git-guards/scripts/git-permission-guard.py
@@ -124,6 +124,9 @@ def _is_on_main_branch() -> bool:
 
     Returns False (fail-open) on any error.
     """
+    override = os.environ.get("GIT_GUARD_BRANCH_OVERRIDE")
+    if override is not None:
+        return override == "main"
     try:
         result = subprocess.run(
             ["git", "rev-parse", "--show-toplevel"],

--- a/git-guards/scripts/git-permission-guard.py
+++ b/git-guards/scripts/git-permission-guard.py
@@ -123,6 +123,10 @@ def _is_on_main_branch() -> bool:
     2. Current branch name == "main" (fallback, git-based)
 
     Returns False (fail-open) on any error.
+
+    GIT_GUARD_BRANCH_OVERRIDE: when set, returns (value == "main") without
+    touching git. Intended for CI/test use only — setting this in production
+    bypasses the branch guard entirely.
     """
     override = os.environ.get("GIT_GUARD_BRANCH_OVERRIDE")
     if override is not None:


### PR DESCRIPTION
## Summary

Added support for `GIT_GUARD_BRANCH_OVERRIDE` environment variable to `_is_on_main_branch()`, allowing tests and CI workflows to mock the main branch detection without invoking git commands.

## Changes

- Added optional `GIT_GUARD_BRANCH_OVERRIDE` env-var check in `_is_on_main_branch()`
- When set, the function returns `(override == "main")` without touching git
- Updated docstring to document the mechanism as CI/test-only
- This avoids git operations during unit testing while maintaining fail-open behavior

## Test Plan

- Unit tests can mock branch detection by setting `GIT_GUARD_BRANCH_OVERRIDE=main` or `GIT_GUARD_BRANCH_OVERRIDE=feature`
- CI workflows can safely test guard behavior without actual branch context
- Unset env-var preserves original behavior (git-based detection)

Closes #261