### PR TITLE
fix(git-guards): allow writes to bare-repo siblings

### DIFF
--- a/codeql-resolver/skills/codeql-permission-classification/SKILL.md
+++ b/codeql-resolver/skills/codeql-permission-classification/SKILL.md
@@ -1,9 +1,6 @@
 ---
 name: codeql-permission-classification
 description: Permission requirements for GitHub Actions
-metadata:
-  version: "1.0.0"
-  author: JacobPEvans
 ---
 
 # CodeQL Permission Classification

--- a/codeql-resolver/skills/github-workflow-security-patterns/SKILL.md
+++ b/codeql-resolver/skills/github-workflow-security-patterns/SKILL.md
@@ -1,9 +1,6 @@
 ---
 name: github-workflow-security-patterns
 description: Canonical security patterns for GitHub Actions workflows
-metadata:
-  version: "1.0.0"
-  author: JacobPEvans
 ---
 
 # GitHub Workflow Security Patterns

--- a/git-guards/scripts/main-branch-guard.py
+++ b/git-guards/scripts/main-branch-guard.py
@@ -26,17 +26,23 @@ def deny(reason: str) -> None:
 
 
 def is_in_git_repo(file_path: str) -> bool:
-    """Check if the file's directory is inside a git repository."""
+    """Check if the file's directory is inside a git work tree.
+
+    `git rev-parse --is-inside-work-tree` exits 0 even for directories
+    adjacent to a bare repo — it prints "false" but the exit status is still
+    0 — so we must inspect the output, not just the exit code. Returns False
+    for bare-repo siblings, scratch dirs, and any path outside a work tree.
+    """
     path = Path(file_path)
     file_dir = str(path.parent)
     try:
         result = subprocess.run(
-            ["git", "rev-parse", "--git-dir"],
+            ["git", "rev-parse", "--is-inside-work-tree"],
             cwd=file_dir,
             capture_output=True,
             text=True,
         )
-        return result.returncode == 0
+        return result.returncode == 0 and result.stdout.strip() == "true"
     except (OSError, subprocess.SubprocessError):
         return False
 

--- a/git-guards/scripts/main-branch-guard.py
+++ b/git-guards/scripts/main-branch-guard.py
@@ -25,7 +25,7 @@ def deny(reason: str) -> None:
     sys.exit(0)
 
 
-def is_in_git_repo(file_path: str) -> bool:
+def is_in_git_worktree(file_path: str) -> bool:
     """Check if the file's directory is inside a git work tree.
 
     `git rev-parse --is-inside-work-tree` exits 0 even for directories
@@ -98,7 +98,7 @@ def main() -> None:
     if not file_path:
         sys.exit(0)
 
-    if not is_in_git_repo(file_path):
+    if not is_in_git_worktree(file_path):
         sys.exit(0)
 
     worktree_root = get_worktree_root(file_path)

--- a/git-guards/scripts/main-branch-guard.sh
+++ b/git-guards/scripts/main-branch-guard.sh
@@ -19,9 +19,14 @@ fi
 # Get the directory containing the file
 file_dir=$(dirname "$file_path")
 
-# Check if the file is inside a git repository (tracked or not).
-# Files outside git repos (e.g., ~/.claude/plans/) are always allowed.
-if ! (cd "$file_dir" 2>/dev/null && git rev-parse --is-inside-work-tree >/dev/null 2>&1); then
+# Check if the file is inside a git work tree (not a bare repo, not outside git).
+# `git rev-parse --is-inside-work-tree` exits 0 even for directories adjacent
+# to a bare repo — it prints "false" but the exit status is still 0 — so we
+# must inspect the output, not just the exit code. Files outside git work
+# trees (e.g. ~/.claude/plans/, or scratch dirs that sit next to a bare repo)
+# are always allowed.
+inside=$(cd "$file_dir" 2>/dev/null && git rev-parse --is-inside-work-tree 2>/dev/null || echo "false")
+if [[ "$inside" != "true" ]]; then
     exit 0
 fi
 

--- a/git-guards/scripts/test_hook.py
+++ b/git-guards/scripts/test_hook.py
@@ -160,6 +160,60 @@ def test_allow_non_edit_tools():
         print(f"❌ Ignore other tools: {actual}")
 
 
+def test_allow_bare_repo_sibling():
+    """Regression: scratch dirs sibling to a bare-repo + main worktree must be allowed.
+
+    Layout:
+        repo_root/        ← bare repo (.git here, HEAD on 'main')
+        repo_root/main/   ← main worktree (BLOCKED — correct)
+        repo_root/scratch/ ← non-worktree scratch dir (must be ALLOWED)
+
+    Before the fix, `git branch --show-current` from `scratch/` walked up to
+    the bare repo and reported `main`, which falsely triggered the deny path.
+    """
+    with tempfile.TemporaryDirectory() as tmpdir:
+        repo_root = Path(tmpdir)
+        bare = repo_root / ".git"
+
+        subprocess.run(
+            ["git", "init", "--bare", "--initial-branch=main", str(bare)],
+            capture_output=True,
+            check=True,
+        )
+
+        # Create main worktree from the bare repo
+        main_worktree = repo_root / "main"
+        # First seed a commit so worktree creation has a HEAD
+        seed = repo_root / "_seed"
+        seed.mkdir()
+        subprocess.run(["git", "init", "--initial-branch=main", str(seed)], capture_output=True, check=True)
+        subprocess.run(["git", "config", "user.email", "t@e.com"], cwd=seed, capture_output=True, check=True)
+        subprocess.run(["git", "config", "user.name", "T"], cwd=seed, capture_output=True, check=True)
+        (seed / "x").write_text("x")
+        subprocess.run(["git", "add", "x"], cwd=seed, capture_output=True, check=True)
+        subprocess.run(["git", "commit", "-m", "seed"], cwd=seed, capture_output=True, check=True)
+        subprocess.run(
+            ["git", "push", str(bare), "main"], cwd=seed, capture_output=True, check=True
+        )
+        subprocess.run(
+            ["git", "--git-dir", str(bare), "worktree", "add", str(main_worktree), "main"],
+            capture_output=True, check=True,
+        )
+
+        # Scratch dir at repo_root/scratch (sibling of main/, NOT a worktree)
+        scratch = repo_root / "scratch"
+        scratch.mkdir()
+        scratch_file = scratch / "snapshot.md"
+
+        output = run_hook("Write", {"file_path": str(scratch_file)})
+        actual = output["hookSpecificOutput"]["permissionDecision"] if output else None
+
+        if actual is None:
+            print("✅ Allow bare-repo sibling: None")
+        else:
+            print(f"❌ Allow bare-repo sibling: {actual}")
+
+
 def test_notebook_edit():
     """Test that NotebookEdit is also guarded."""
     for main_worktree in setup_test_repo():
@@ -182,6 +236,7 @@ def main():
     test_allow_for_non_main()
     test_allow_non_edit_tools()
     test_notebook_edit()
+    test_allow_bare_repo_sibling()
 
 
 if __name__ == "__main__":

--- a/git-guards/scripts/test_hook.py
+++ b/git-guards/scripts/test_hook.py
@@ -70,10 +70,8 @@ def test_deny_in_main_worktree():
         output = run_hook("Edit", {"file_path": str(test_file)})
         actual = output["hookSpecificOutput"]["permissionDecision"] if output else None
 
-        if actual == "deny":
-            print("✅ Deny in main worktree: deny")
-        else:
-            print(f"❌ Deny in main worktree: {actual}")
+        assert actual == "deny", f"Expected deny in main worktree, got {actual!r}"
+        print("✅ Deny in main worktree: deny")
 
 
 def test_deny_on_main_branch():
@@ -91,10 +89,8 @@ def test_deny_on_main_branch():
         output = run_hook("Write", {"file_path": str(test_file)})
         actual = output["hookSpecificOutput"]["permissionDecision"] if output else None
 
-        if actual == "deny":
-            print("✅ Deny when branch is main: deny")
-        else:
-            print(f"❌ Deny when branch is main: {actual}")
+        assert actual == "deny", f"Expected deny when branch is main, got {actual!r}"
+        print("✅ Deny when branch is main: deny")
 
 
 def test_allow_for_non_main():
@@ -143,10 +139,8 @@ def test_allow_for_non_main():
         output = run_hook("Edit", {"file_path": str(test_file)})
         actual = output["hookSpecificOutput"]["permissionDecision"] if output else None
 
-        if actual is None:
-            print("✅ Allow for non-main: None")
-        else:
-            print(f"❌ Allow for non-main: {actual}")
+        assert actual is None, f"Expected allow for non-main, got {actual!r}"
+        print("✅ Allow for non-main: None")
 
 
 def test_allow_non_edit_tools():
@@ -154,10 +148,8 @@ def test_allow_non_edit_tools():
     output = run_hook("Read", {"file_path": "/tmp/test.txt"})
     actual = output["hookSpecificOutput"]["permissionDecision"] if output else None
 
-    if actual is None:
-        print("✅ Ignore other tools: None")
-    else:
-        print(f"❌ Ignore other tools: {actual}")
+    assert actual is None, f"Expected allow for non-edit tools, got {actual!r}"
+    print("✅ Ignore other tools: None")
 
 
 def test_allow_bare_repo_sibling():
@@ -186,18 +178,46 @@ def test_allow_bare_repo_sibling():
         # First seed a commit so worktree creation has a HEAD
         seed = repo_root / "_seed"
         seed.mkdir()
-        subprocess.run(["git", "init", "--initial-branch=main", str(seed)], capture_output=True, check=True)
-        subprocess.run(["git", "config", "user.email", "t@e.com"], cwd=seed, capture_output=True, check=True)
-        subprocess.run(["git", "config", "user.name", "T"], cwd=seed, capture_output=True, check=True)
-        (seed / "x").write_text("x")
-        subprocess.run(["git", "add", "x"], cwd=seed, capture_output=True, check=True)
-        subprocess.run(["git", "commit", "-m", "seed"], cwd=seed, capture_output=True, check=True)
         subprocess.run(
-            ["git", "push", str(bare), "main"], cwd=seed, capture_output=True, check=True
+            ["git", "init", "--initial-branch=main", str(seed)],
+            capture_output=True,
+            check=True,
+        )
+        subprocess.run(
+            ["git", "config", "user.email", "t@e.com"],
+            cwd=seed,
+            capture_output=True,
+            check=True,
+        )
+        subprocess.run(
+            ["git", "config", "user.name", "T"],
+            cwd=seed,
+            capture_output=True,
+            check=True,
+        )
+        (seed / "x").write_text("x")
+        subprocess.run(
+            ["git", "add", "x"],
+            cwd=seed,
+            capture_output=True,
+            check=True,
+        )
+        subprocess.run(
+            ["git", "commit", "-m", "seed"],
+            cwd=seed,
+            capture_output=True,
+            check=True,
+        )
+        subprocess.run(
+            ["git", "push", str(bare), "main"],
+            cwd=seed,
+            capture_output=True,
+            check=True,
         )
         subprocess.run(
             ["git", "--git-dir", str(bare), "worktree", "add", str(main_worktree), "main"],
-            capture_output=True, check=True,
+            capture_output=True,
+            check=True,
         )
 
         # Scratch dir at repo_root/scratch (sibling of main/, NOT a worktree)
@@ -208,10 +228,8 @@ def test_allow_bare_repo_sibling():
         output = run_hook("Write", {"file_path": str(scratch_file)})
         actual = output["hookSpecificOutput"]["permissionDecision"] if output else None
 
-        if actual is None:
-            print("✅ Allow bare-repo sibling: None")
-        else:
-            print(f"❌ Allow bare-repo sibling: {actual}")
+        assert actual is None, f"Allow bare-repo sibling regression: expected None, got {actual!r}"
+        print("✅ Allow bare-repo sibling: None")
 
 
 def test_notebook_edit():
@@ -223,10 +241,8 @@ def test_notebook_edit():
         output = run_hook("NotebookEdit", {"notebook_path": str(notebook)})
         actual = output["hookSpecificOutput"]["permissionDecision"] if output else None
 
-        if actual == "deny":
-            print("✅ Deny NotebookEdit in main: deny")
-        else:
-            print(f"❌ Deny NotebookEdit in main: {actual}")
+        assert actual == "deny", f"Expected deny for NotebookEdit in main, got {actual!r}"
+        print("✅ Deny NotebookEdit in main: deny")
 
 
 def main():

--- a/git-guards/scripts/test_hook.py
+++ b/git-guards/scripts/test_hook.py
@@ -5,6 +5,7 @@ import json
 import subprocess
 import sys
 import tempfile
+from contextlib import contextmanager
 from pathlib import Path
 
 HOOK = Path(__file__).parent / "main-branch-guard.py"
@@ -21,6 +22,7 @@ def run_hook(tool_name: str, tool_input: dict) -> dict | None:
     return json.loads(result.stdout) if result.stdout.strip() else None
 
 
+@contextmanager
 def setup_test_repo():
     """Create a temporary git repo with main worktree structure."""
     with tempfile.TemporaryDirectory() as tmpdir:
@@ -63,7 +65,7 @@ def setup_test_repo():
 
 def test_deny_in_main_worktree():
     """Test that editing files in main worktree is denied."""
-    for main_worktree in setup_test_repo():
+    with setup_test_repo() as main_worktree:
         test_file = main_worktree / "README.md"
         test_file.write_text("# Test")
 
@@ -76,7 +78,7 @@ def test_deny_in_main_worktree():
 
 def test_deny_on_main_branch():
     """Test that editing files on main branch is denied."""
-    for main_worktree in setup_test_repo():
+    with setup_test_repo() as main_worktree:
         # Ensure we're on main branch
         subprocess.run(
             ["git", "checkout", "-b", "main"],
@@ -234,7 +236,7 @@ def test_allow_bare_repo_sibling():
 
 def test_notebook_edit():
     """Test that NotebookEdit is also guarded."""
-    for main_worktree in setup_test_repo():
+    with setup_test_repo() as main_worktree:
         notebook = main_worktree / "test.ipynb"
         notebook.write_text('{"cells": []}')
 

--- a/github-workflows/skills/rebase-pr/SKILL.md
+++ b/github-workflows/skills/rebase-pr/SKILL.md
@@ -1,8 +1,6 @@
 ---
 name: rebase-pr
 description: Local rebase-merge workflow for pull requests with signed commits
-metadata:
-  version: 2.0.0
 ---
 
 # rebase-pr

--- a/session-analytics/skills/token-breakdown/SKILL.md
+++ b/session-analytics/skills/token-breakdown/SKILL.md
@@ -1,9 +1,6 @@
 ---
 name: token-breakdown
 description: Analyze current Claude Code session token usage via Splunk. Shows per-model, per-tool, and subagent token breakdown with cache efficiency metrics.
-metadata:
-  version: "1.0.0"
-  author: JacobPEvans
 ---
 
 # Token Breakdown

--- a/tests/git-guards/main-branch-guard/main-branch-guard.bats
+++ b/tests/git-guards/main-branch-guard/main-branch-guard.bats
@@ -116,3 +116,41 @@ run_hook() {
   run_hook '{"tool_name":"NotebookEdit","tool_input":{"notebook_path":"'"$tmpfile"'"}}'
   [ "$status" -eq 0 ]
 }
+
+# ---------------------------------------------------------------------------
+# TC7: file in bare-repo sibling (scratch dir, not a worktree) -> allow (exit 0)
+# Regression: before the fix, git branch --show-current walked up to the bare
+# repo and returned "main", falsely triggering the deny path.
+# ---------------------------------------------------------------------------
+
+@test "TC7: file in bare-repo sibling (not a worktree) is allowed" {
+  local bare_dir seed_dir main_worktree scratch_dir scratch_file
+  bare_dir="$TMPDIR_BASE/.git"
+  seed_dir="$TMPDIR_BASE/_seed"
+  main_worktree="$TMPDIR_BASE/main"
+  scratch_dir="$TMPDIR_BASE/scratch"
+
+  # Create bare repo
+  git init --bare -q "$bare_dir"
+
+  # Seed a commit via a temporary clone
+  mkdir -p "$seed_dir"
+  git -C "$seed_dir" init -q
+  git -C "$seed_dir" config user.email "test@example.com"
+  git -C "$seed_dir" config user.name "Test"
+  echo "x" > "$seed_dir/x"
+  git -C "$seed_dir" add x
+  git -C "$seed_dir" commit -q -m "seed"
+  git -C "$seed_dir" branch -M main
+  git -C "$seed_dir" push -q "$bare_dir" main
+
+  # Add main worktree from the bare repo
+  git --git-dir="$bare_dir" worktree add -q "$main_worktree" main
+
+  # Create scratch sibling dir (NOT a worktree)
+  mkdir -p "$scratch_dir"
+  scratch_file="$scratch_dir/snapshot.md"
+
+  run_hook '{"tool_name":"Write","tool_input":{"file_path":"'"$scratch_file"'"}}'
+  [ "$status" -eq 0 ]
+}


### PR DESCRIPTION
## Summary

`main-branch-guard` was blocking writes to scratch directories that sit **alongside** a bare repo + `main/` worktree, even though those scratch dirs are not in any worktree.

Example layout that triggered the false positive:

```text
~/git/<repo>/
├── .git/         ← bare repo, HEAD on main
├── main/         ← main worktree (correctly blocked)
├── feature/<name>/
└── scratch/      ← NOT a worktree — was being blocked
```

## Root Cause

`git rev-parse --is-inside-work-tree` exits 0 even when printing `false`. The hook's first guard checked only the exit code, so bare-repo siblings passed through. The fallback `git branch --show-current` then walked up to the bare repo, returned its HEAD branch (`main`), and triggered the deny.

## Changes

### Core Fix
1. **Shell hook** (`main-branch-guard.sh`): Now requires `--is-inside-work-tree` to output exactly `"true"` before proceeding.
2. **Python hook** (`main-branch-guard.py`): Aligned to same pattern; replaced `--git-dir` check with `--is-inside-work-tree` output validation.
3. **Test coverage**: Added `test_allow_bare_repo_sibling` to `test_hook.py` (TC7 in bats) to verify the exact bare-repo + main-worktree + scratch-sibling layout is allowed.

### Review Feedback & Refactoring
4. **Python code improvements**:
   - Renamed `is_in_git_repo` → `is_in_git_worktree` for clarity
   - Added assert statements to all test functions
   - Reformatted subprocess.run calls to multi-line style

5. **Test infrastructure**:
   - Converted `setup_test_repo` from generator-with-for to `@contextmanager` pattern for cleaner setup/teardown

6. **Skill cleanup**:
   - Removed unused `metadata.version` and `metadata.author` from 4 SKILL.md files (consolidation prep)

## Test Plan

- [x] All Python tests pass: `pytest git-guards/scripts/test_hook.py -v`
- [x] Bats test coverage includes bare-repo sibling scenario
- [x] Manual verification: shell hook exits 0 for bare-repo sibling paths, exits 2 for main worktree
- [ ] CI tests pass
- [ ] Reviewer confirms regression test exercises the bare-repo sibling path and not just any non-worktree path

Generated with [Claude Code](https://claude.com/claude-code)