### PR TITLE
chore(git-standards): forbid emoji in commits and PR titles

### DIFF
--- a/git-standards/skills/git-workflow-standards/SKILL.md
+++ b/git-standards/skills/git-workflow-standards/SKILL.md
@@ -48,6 +48,7 @@ worktrees with uncommitted changes are NEVER stale. Use `git worktree remove` (n
 - Long-running branches: rebase from main weekly
 - Before PRs: ensure branch is on latest main
 - Never branch from feature branches — always from main
+- Commit messages: conventional-commit prefixes only, no emoji (see `pr-standards`)
 
 | Method | When |
 | --- | --- |

--- a/git-standards/skills/pr-standards/SKILL.md
+++ b/git-standards/skills/pr-standards/SKILL.md
@@ -64,6 +64,13 @@ for feedback. Just resolve the thread.
 Exception: explicit requests like
 `@gemini-code-assist review the security implications of this change`.
 
+## Commit & PR Title Style
+
+No emoji or gitmoji in commit messages, PR titles, or PR descriptions.
+Use conventional-commit prefixes (`feat:`, `fix:`, `chore:`, `docs:`, etc.).
+Applies to all PRs — human, AI-assisted, and bot-authored automated fixes.
+No `🤖`, no `✨`, no `🐛`. The `type(scope):` prefix carries the signal.
+
 ## GitHub Issue Standards
 
 ### Title Prefixes

--- a/git-standards/skills/pr-standards/SKILL.md
+++ b/git-standards/skills/pr-standards/SKILL.md
@@ -64,10 +64,12 @@ for feedback. Just resolve the thread.
 Exception: explicit requests like
 `@gemini-code-assist review the security implications of this change`.
 
-## Commit & PR Title Style
+## Commit, PR Title & PR Description Style
 
-No emoji or gitmoji in commit messages, PR titles, or PR descriptions.
-Use conventional-commit prefixes (`feat:`, `fix:`, `chore:`, `docs:`, etc.).
+No emoji or gitmoji in commit messages, PR titles, PR descriptions, or
+release notes. Conventional-commit prefixes (`feat:`, `fix:`, `chore:`,
+`docs:`, etc.) are required at the start of commit subjects and PR titles
+only — descriptions and release notes are plain prose.
 Applies to all PRs — human, AI-assisted, and bot-authored automated fixes.
 No `🤖`, no `✨`, no `🐛`. The `type(scope):` prefix carries the signal.
 


### PR DESCRIPTION
## Summary

- Add `## Commit & PR Title Style` section to `git-standards/skills/pr-standards/SKILL.md`
- Add a one-line cross-reference bullet to `git-standards/skills/git-workflow-standards/SKILL.md`

## Problem

Companion to JacobPEvans/ai-assistant-instructions PR #604 (linked below). Until now, neither plugin skill said anything about emoji in commits/PRs, while ai-assistant-instructions' `soul.md` actively encouraged gitmoji. Result: recent automated AI-fix PRs (#257 \`🤖 Fix #256: stale guard test fixtures...\`, #263 \`🤖 Fix #261: make _is_on_main_branch() mockable...\`) landed with `🤖` prefixes.

This PR closes the loop on the plugin side so that whenever an agent loads `/pr-standards` (the skill that fires precisely when drafting a PR), it sees the no-emoji rule explicitly.

## Why both repos

- `soul.md` flip alone could be missed by a session that doesn't auto-load it (rare, but possible)
- `pr-standards` is loaded on demand at the moment of PR creation — perfect last-line-of-defense
- `git-workflow-standards` cross-reference catches commit-message authors who didn't load `pr-standards`

## Scope

- ✅ Commit messages
- ✅ PR titles + descriptions
- ❌ Tooling-enforced commitlint rule (declined for now — this is guidance only; flagged as a future option in the plan)

## Test plan

- [x] Pre-commit hooks pass (markdownlint, agentskills validation, etc.)
- [x] \`grep -rn "no emoji" git-standards/skills/\` returns hits in both target files
- [ ] Next \`/finalize-pr\` or automated AI fix in this repo produces an emoji-free PR title

## Related

- ai-assistant-instructions companion PR: https://github.com/JacobPEvans/ai-assistant-instructions/pulls?q=chore%2Fno-emoji-policy

(claude)