### PR TITLE
feat(git-guards): block sign-disable bypasses

### DIFF
--- a/git-guards/scripts/git-permission-guard.py
+++ b/git-guards/scripts/git-permission-guard.py
@@ -24,10 +24,12 @@ DENY_ALWAYS = [
 # positives from matching substrings in gh api body text or other commands
 DENY_GIT_ONLY = [
     (r"commit\s+.*(?<![\w-])(-\w*n\w*|--no-verify)\b", "bypasses pre-commit hooks"),
+    (r"commit\s+.*--no-gpg-sign\b", "disables commit signing (required_signatures rejects unsigned commits)"),
     (r"merge\s+.*--no-verify", "bypasses merge hooks"),
     (r"cherry-pick\s+.*--no-verify", "bypasses commit hooks"),
     (r"rebase\s+.*--no-verify", "bypasses commit hooks"),
     (r"config\s+.*core\.hooksPath", "changes hook directory"),
+    (r"config\s+.*(commit|tag)\.gpgsign", "disables commit/tag signing"),
     (r"^push\s+.*(--force|--force-with-lease|-f)\b", "force-pushes overwrite remote history"),
 ]
 
@@ -328,12 +330,14 @@ def main():
         for pattern, reason in DENY_GIT_ONLY:
             if re.search(pattern, subcommand, re.IGNORECASE):
                 deny(f"This command {reason}. Fix the underlying issue instead.")
-        # Check git -c config options for hook bypass attempts.
+        # Check git -c config options for hook/signing bypass attempts.
         # Anchor to the key portion to avoid false positives where the value
-        # contains 'core.hooksPath' as a substring.
+        # contains the key name as a substring.
         for opt in git_config_opts:
             if re.match(r"core\.hooksPath\s*(?:=|$)", opt, re.IGNORECASE):
                 deny("This command bypasses configured hooks. Fix the underlying issue instead.")
+            if re.match(r"(commit|tag)\.gpgsign\s*(?:=|$)", opt, re.IGNORECASE):
+                deny("This command disables commit/tag signing. Fix the underlying issue instead.")
         # Fallback: detect -c core.hooksPath remaining in the subcommand when the
         # extraction loop broke early on an unrecognised git global option.
         # Successfully parsed -c opts are stripped from subcommand, so this
@@ -353,6 +357,8 @@ def main():
                 config_token = subcmd_tokens[i + 1]
                 if re.match(r"^core\.hooksPath(=|$)", config_token, re.IGNORECASE):
                     deny("This command bypasses configured hooks. Fix the underlying issue instead.")
+                if re.match(r"^(commit|tag)\.gpgsign(=|$)", config_token, re.IGNORECASE):
+                    deny("This command disables commit/tag signing. Fix the underlying issue instead.")
 
         if sub_tokens and sub_tokens[0] in BLOCKED_ON_MAIN and _is_on_main_branch():
             deny(

--- a/git-guards/scripts/git-permission-guard.py
+++ b/git-guards/scripts/git-permission-guard.py
@@ -24,12 +24,14 @@ DENY_ALWAYS = [
 # positives from matching substrings in gh api body text or other commands
 DENY_GIT_ONLY = [
     (r"commit\s+.*(?<![\w-])(-\w*n\w*|--no-verify)\b", "bypasses pre-commit hooks"),
-    (r"commit\s+.*--no-gpg-sign\b", "disables commit signing (required_signatures rejects unsigned commits)"),
+    (r"^(commit|tag)\s+.*(?<![\w-])--no-gpg-sign\b", "disables commit/tag signing (required_signatures rejects unsigned)"),
     (r"merge\s+.*--no-verify", "bypasses merge hooks"),
     (r"cherry-pick\s+.*--no-verify", "bypasses commit hooks"),
     (r"rebase\s+.*--no-verify", "bypasses commit hooks"),
     (r"config\s+.*core\.hooksPath", "changes hook directory"),
-    (r"config\s+.*(commit|tag)\.gpgsign", "disables commit/tag signing"),
+    # Only block explicit value-disabling forms; allow `--get`, `--unset`, and `commit.gpgsign true`.
+    (r"^config\s+(?!.*--(?:get|list|unset))(?:\S+\s+)*\b(?:commit|tag)\.gpgsign\s+(?:false|0|off|no)\b", "disables commit/tag signing"),
+    (r"^config\s+--unset\s+(?:commit|tag)\.gpgsign\b", "unsetting reverts signing to default-off"),
     (r"^push\s+.*(--force|--force-with-lease|-f)\b", "force-pushes overwrite remote history"),
 ]
 
@@ -336,7 +338,8 @@ def main():
         for opt in git_config_opts:
             if re.match(r"core\.hooksPath\s*(?:=|$)", opt, re.IGNORECASE):
                 deny("This command bypasses configured hooks. Fix the underlying issue instead.")
-            if re.match(r"(commit|tag)\.gpgsign\s*(?:=|$)", opt, re.IGNORECASE):
+            # Only deny explicit false values; allow `=true` and missing-value (which means true).
+            if re.match(r"^(?:commit|tag)\.gpgsign\s*=\s*(?:false|0|off|no)\b", opt, re.IGNORECASE):
                 deny("This command disables commit/tag signing. Fix the underlying issue instead.")
         # Fallback: detect -c core.hooksPath remaining in the subcommand when the
         # extraction loop broke early on an unrecognised git global option.
@@ -357,7 +360,7 @@ def main():
                 config_token = subcmd_tokens[i + 1]
                 if re.match(r"^core\.hooksPath(=|$)", config_token, re.IGNORECASE):
                     deny("This command bypasses configured hooks. Fix the underlying issue instead.")
-                if re.match(r"^(commit|tag)\.gpgsign(=|$)", config_token, re.IGNORECASE):
+                if re.match(r"^(?:commit|tag)\.gpgsign\s*=\s*(?:false|0|off|no)\b", config_token, re.IGNORECASE):
                     deny("This command disables commit/tag signing. Fix the underlying issue instead.")
 
         if sub_tokens and sub_tokens[0] in BLOCKED_ON_MAIN and _is_on_main_branch():

--- a/git-guards/scripts/test_permission_guard.py
+++ b/git-guards/scripts/test_permission_guard.py
@@ -102,11 +102,17 @@ all_pass &= check("git commit --amend --no-edit allow", "git commit --amend --no
 # DENY: remove hooks
 all_pass &= check("rm .git/hooks", "rm .git/hooks/pre-commit", "deny")
 
-# DENY: --no-gpg-sign disables commit signing (required_signatures rejects unsigned)
+# DENY: --no-gpg-sign on commit (required_signatures rejects unsigned)
 all_pass &= check("git commit --no-gpg-sign", "git commit -m msg --no-gpg-sign", "deny")
+
+# DENY: --no-gpg-sign on tag
+all_pass &= check("git tag --no-gpg-sign", "git tag --no-gpg-sign v1.0", "deny")
 
 # DENY: -c commit.gpgsign=false bypasses signing for one invocation
 all_pass &= check("git -c commit.gpgsign=false commit", "git -c commit.gpgsign=false commit -m msg", "deny")
+
+# DENY: -c commit.gpgsign=0 (numeric false form)
+all_pass &= check("git -c commit.gpgsign=0 commit", "git -c commit.gpgsign=0 commit -m msg", "deny")
 
 # DENY: -c tag.gpgsign=false bypasses tag signing
 all_pass &= check("git -c tag.gpgsign=false tag", "git -c tag.gpgsign=false tag v1.0", "deny")
@@ -116,6 +122,24 @@ all_pass &= check("git config commit.gpgsign false", "git config commit.gpgsign 
 
 # DENY: git config --global tag.gpgsign false
 all_pass &= check("git config --global tag.gpgsign false", "git config --global tag.gpgsign false", "deny")
+
+# DENY: git config --unset commit.gpgsign reverts to default-off
+all_pass &= check("git config --unset commit.gpgsign", "git config --unset commit.gpgsign", "deny")
+
+# ALLOW: -c commit.gpgsign=true forces signing for one invocation (legitimate)
+all_pass &= check("git -c commit.gpgsign=true commit", "git -c commit.gpgsign=true commit -m msg", "silent_allow")
+
+# ALLOW: -c commit.gpgsign with no value (git treats missing value as true)
+all_pass &= check("git -c commit.gpgsign commit", "git -c commit.gpgsign commit -m msg", "silent_allow")
+
+# ALLOW: enabling signing in config
+all_pass &= check("git config commit.gpgsign true", "git config commit.gpgsign true", "silent_allow")
+
+# ALLOW: reading signing config
+all_pass &= check("git config --get commit.gpgsign", "git config --get commit.gpgsign", "silent_allow")
+
+# ALLOW: listing signing config
+all_pass &= check("git config --list commit.gpgsign", "git config --list", "silent_allow")
 
 # False positive guard: commit message containing 'commit.gpgsign' must not deny
 all_pass &= check("commit.gpgsign in message", 'git -c user.name=test tag v99-test -m "allow commit.gpgsign bypass example"', "silent_allow")

--- a/git-guards/scripts/test_permission_guard.py
+++ b/git-guards/scripts/test_permission_guard.py
@@ -102,6 +102,24 @@ all_pass &= check("git commit --amend --no-edit allow", "git commit --amend --no
 # DENY: remove hooks
 all_pass &= check("rm .git/hooks", "rm .git/hooks/pre-commit", "deny")
 
+# DENY: --no-gpg-sign disables commit signing (required_signatures rejects unsigned)
+all_pass &= check("git commit --no-gpg-sign", "git commit -m msg --no-gpg-sign", "deny")
+
+# DENY: -c commit.gpgsign=false bypasses signing for one invocation
+all_pass &= check("git -c commit.gpgsign=false commit", "git -c commit.gpgsign=false commit -m msg", "deny")
+
+# DENY: -c tag.gpgsign=false bypasses tag signing
+all_pass &= check("git -c tag.gpgsign=false tag", "git -c tag.gpgsign=false tag v1.0", "deny")
+
+# DENY: git config commit.gpgsign false persists the bypass
+all_pass &= check("git config commit.gpgsign false", "git config commit.gpgsign false", "deny")
+
+# DENY: git config --global tag.gpgsign false
+all_pass &= check("git config --global tag.gpgsign false", "git config --global tag.gpgsign false", "deny")
+
+# False positive guard: commit message containing 'commit.gpgsign' must not deny
+all_pass &= check("commit.gpgsign in message", 'git -c user.name=test tag v99-test -m "allow commit.gpgsign bypass example"', "silent_allow")
+
 # Non-git command: silent allow
 all_pass &= check("ls command", "ls -la", "silent_allow")
 


### PR DESCRIPTION
## Summary

- Block AI tools from disabling commit signing via `--no-gpg-sign`, `-c {commit,tag}.gpgsign=false`, or `git config {commit,tag}.gpgsign false`.
- Three new patterns added to existing `git-permission-guard.py` (mirrors the existing `core.hooksPath` defense), plus six new tests.
- Replaces the abandoned standalone sign-guard approach in #271 — extending the existing guard keeps policy in one file.

## Why

`required_signatures` is enforced on every JacobPEvans repo. Unsigned commits get rejected at push time, but the rejection happens AFTER the work — so an AI session that runs `git commit --no-gpg-sign` wastes time and risks confusion. This blocks the bypass at the tool-use layer instead.

Part of the cross-repo unsigned-commits cleanup (Phase 1 of plan: ~/.claude/plans/analyze-all-open-jacobpevans-giggly-cray.md). Pairs with JacobPEvans/nix-home#223 (gpg-agent unattended-session config) — together they make unsigned local commits structurally hard to produce.

## Test plan

- [x] All 33 tests pass (`python3 git-guards/scripts/test_permission_guard.py`)
- [ ] CI green