### PR TITLE
feat(categories): add canonical category metadata schema

### DIFF
--- a/.claude-plugin/categories.md
+++ b/.claude-plugin/categories.md
@@ -91,25 +91,54 @@ pattern.
 
 ## Adding a new category
 
-1. Pick a name (kebab-case, descriptive — e.g. `data-engineering`, `mobile-dev`).
-2. Add an entry to `defaults` with a sensible `enabled` default.
-3. Add the matching entry to `members` listing plugin refs, skill names, and any
-   synthesized command-skill names.
-4. Open a PR to claude-code-plugins.
-5. Once merged, bump the `jacobpevans-cc-plugins` flake input in nix-ai and run
-   `nix flake check` — eval-time assertions catch typos and structural bugs.
+`categories.nix` auto-discovers any `*.nix` file in `./categories/`. Adding a
+new category is a single-file change:
+
+1. Pick a name (kebab-case, descriptive — e.g. `data-engineering`,
+   `mobile-dev`). The filename (sans `.nix`) becomes the category name.
+2. Create `./categories/<name>.nix` returning an attrset:
+
+   ```nix
+   {
+     default = { enabled = false; };  # or true; add `alwaysOn = true;` for core-like
+     claudePlugins  = [ "<plugin>@<marketplace>" ];
+     skills         = [ "<skill-folder-name>" ];
+     claudeCommands = [ "<plugin>-<command>" ];   # synthesized; only for
+                                                  # plugins in marketplaces
+                                                  # that get discoverClaudeCommands
+   }
+   ```
+
+3. Open a PR to claude-code-plugins. The eval-time assertion in
+   `categories.nix` checks for duplicate skill names across categories.
+4. Once merged, bump the `jacobpevans-cc-plugins` flake input in nix-ai and
+   run `nix flake check` — additional structural assertions there catch
+   typos in the consumer wiring.
+
+You do NOT edit `categories.nix` itself when adding a category. It walks
+`./categories/` automatically.
 
 ## Renaming or removing a category
 
-Categories are user-facing API. Renames are breaking changes. If you must rename:
+Categories are user-facing API (users reference them in
+`programs.claude.plugins.categories.{disabled,enableOnly}`). Renames and
+removals are breaking changes.
 
-1. Add the new name to both `defaults` and `members` in one PR.
-2. Wait at least one nix-ai release cycle so users can migrate their `disabled`
-   / `enableOnly` lists.
-3. Remove the old name in a follow-up PR.
+To rename:
 
-For removals, the same two-step rule applies — leave the empty members entry
-around for one release before deleting.
+1. Copy the existing category file to the new name; keep both files in one PR.
+2. Wait at least one nix-ai release cycle so users can migrate their lists.
+3. Delete the old file in a follow-up PR.
+
+To remove:
+
+1. Empty the members lists (`claudePlugins = []; skills = []; claudeCommands = [];`)
+   but keep the file in place so the category name still exists. Bump version
+   notes.
+2. Delete the file after one nix-ai release cycle.
+
+The "empty file then delete" two-step gives users a release window to remove
+references from their configs without eval-time errors.
 
 ## Known limitations
 

--- a/.claude-plugin/categories.md
+++ b/.claude-plugin/categories.md
@@ -1,0 +1,127 @@
+# Plugin / Skill Categories
+
+Canonical categorization metadata for Claude Code plugins and shared agent skills,
+consumed by both nix-ai and nix-devenv. Lets users opt-out of plugin/skill bundles
+they don't need (or whitelist the ones they do) at the home-manager layer, with
+optional per-project re-enablement via direnv shells.
+
+The schema lives in `categories.nix` next to this file. Both nix-ai modules import
+it via the existing `jacobpevans-cc-plugins` flake input.
+
+## Why categorize
+
+Claude Code, Codex, and Gemini all auto-load every plugin and skill from every
+registered marketplace. The combined skill list grows unbounded — many skills are
+relevant only situationally (Microsoft Office formats, Obsidian markdown, browser
+automation, etc.) yet still consume context budget and create false-positive
+trigger candidates for the skill router. Categories let you trim the default set
+down to what you actually use, and pull in extras when you need them.
+
+## Schema
+
+```nix
+{
+  schemaVersion = 1;
+
+  defaults.<category> = {
+    enabled  :: Bool;     # default state
+    alwaysOn :: Bool?;    # if true, cannot be disabled or excluded by enableOnly
+  };
+
+  members.<category> = {
+    claudePlugins  :: [String];   # "<plugin>@<marketplace>" refs masked off
+                                  # in ~/.claude/settings.json
+    skills         :: [String];   # SKILL.md folder names filtered out of
+                                  # ~/.agents/skills/
+    claudeCommands :: [String];   # synthesized "<plugin>-<command>" names from
+                                  # agent-skills discoverClaudeCommands
+  };
+}
+```
+
+## Plugin-level vs skill-level granularity (asymmetry)
+
+Two parallel skill-delivery systems consume this schema:
+
+1. **Claude plugins** (`programs.claude.plugins.enabled` →
+   `~/.claude/settings.json`) — plugin-level. Disabling a category drops every
+   plugin in `claudePlugins` whole. Side-effect: bundled plugins like
+   `document-skills` lose all their skills (pptx + docx + xlsx + pdf +
+   canvas-design + ...).
+2. **agentSkills** (`~/.agents/skills/<name>/SKILL.md`, consumed by Codex,
+   Gemini, and Claude) — skill-level. Disabling a category filters by SKILL.md
+   folder name. So `microsoft-office` only drops `pptx`, `docx`, `xlsx` SKILL.md
+   files — `pdf`, `canvas-design`, etc. still deploy.
+
+This means disabling `microsoft-office` gives you:
+
+- **Claude Code**: loses pptx + docx + xlsx **plus** pdf, canvas-design,
+  frontend-design, claude-api, mcp-builder, theme-factory, algorithmic-art,
+  skill-creator, doc-coauthoring, web-artifacts-builder, webapp-testing —
+  because they all live in the same `document-skills` plugin and Claude Code
+  only toggles at plugin level.
+- **Codex / Gemini**: loses **only** pptx, docx, xlsx. Other skills survive
+  because we filter by SKILL.md name, not by parent plugin.
+
+If the Claude-side over-pruning bites you, see Phase 2 in the design plan:
+synthetic marketplaces split bundled plugins into smaller per-category plugins
+so Claude Code can also be surgical. Pattern already exists in nix-ai
+(`modules/claude/marketplace-overrides.nix` → `browserUseMarketplace`,
+`fabricMarketplace`).
+
+## How activation works (high level)
+
+- **Global default** — set
+  `programs.claude.plugins.categories.disabled = [ "microsoft-office" ]` in your
+  nix-darwin config. After `darwin-rebuild`, `~/.claude/settings.json` and
+  `~/.agents/skills/` reflect the mask.
+- **Whitelist** — set
+  `programs.claude.plugins.categories.enableOnly = [ "infra" ]` for an
+  aggressive minimum. `core` is implicitly added; cannot be excluded.
+- **Per-project re-enable** — use
+  `nix-devenv.lib.mkClaudeShell { enable = [ "microsoft-office" ]; }` in a
+  repo's `flake.nix` plus direnv. On `cd` into the repo, the shell hook writes
+  `${PROJECT_ROOT}/.claude/settings.json` enabling the plugin refs for that
+  category. On `cd` out, the overlay is removed. (Claude Code only —
+  agentSkills is global.)
+
+See `nix-ai/modules/claude/plugins/CATEGORIES.md` for the full activation
+reference and `nix-devenv/shells/claude-categories/README.md` for the devshell
+pattern.
+
+## Adding a new category
+
+1. Pick a name (kebab-case, descriptive — e.g. `data-engineering`, `mobile-dev`).
+2. Add an entry to `defaults` with a sensible `enabled` default.
+3. Add the matching entry to `members` listing plugin refs, skill names, and any
+   synthesized command-skill names.
+4. Open a PR to claude-code-plugins.
+5. Once merged, bump the `jacobpevans-cc-plugins` flake input in nix-ai and run
+   `nix flake check` — eval-time assertions catch typos and structural bugs.
+
+## Renaming or removing a category
+
+Categories are user-facing API. Renames are breaking changes. If you must rename:
+
+1. Add the new name to both `defaults` and `members` in one PR.
+2. Wait at least one nix-ai release cycle so users can migrate their `disabled`
+   / `enableOnly` lists.
+3. Remove the old name in a follow-up PR.
+
+For removals, the same two-step rule applies — leave the empty members entry
+around for one release before deleting.
+
+## Known limitations
+
+- **Skill-name conflicts** — two categories must not share a skill name; the
+  `skillsToDrop` resolver does not detect duplicates. Eval-time validation in
+  nix-ai checks this.
+- **External marketplace coverage** — categories can reference plugins from any
+  marketplace, but skill-level filtering only works for marketplaces that
+  nix-ai's `agent-skills/default.nix` actually imports into `sharedSkills`.
+  Today that's: `jacobpevans-cc-plugins`, `vct-cribl-pack-validator-skills`,
+  `huggingface-skills`, `claude-plugins-official`. Adding more marketplaces is
+  a one-line change there.
+- **MCP servers** — out of scope. MCP server enablement is handled separately
+  by `programs.claude.mcpServers.<name>.disabled`. If categories prove useful,
+  extending this schema with `mcpServers = [ ... ]` is a Phase 2 enhancement.

--- a/.claude-plugin/categories.nix
+++ b/.claude-plugin/categories.nix
@@ -1,0 +1,35 @@
+# Plugin / Skill Categories — entry point.
+# Schema, asymmetry notes, and how-to-add-a-category are in categories.md.
+# Per-category data lives in ./categories/<name>.nix to keep files small.
+let
+  importCategory = name: import ./categories/${name}.nix;
+
+  categoryNames = [
+    "core"
+    "infra"
+    "microsoft-office"
+    "obsidian"
+    "fabric"
+    "browser-automation"
+    "visualization"
+    "huggingface"
+  ];
+
+  loaded = builtins.listToAttrs (
+    map (name: {
+      inherit name;
+      value = importCategory name;
+    }) categoryNames
+  );
+in
+{
+  schemaVersion = 1;
+
+  defaults = builtins.mapAttrs (_: c: c.default) loaded;
+
+  members = builtins.mapAttrs (_: c: {
+    claudePlugins = c.claudePlugins or [ ];
+    skills = c.skills or [ ];
+    claudeCommands = c.claudeCommands or [ ];
+  }) loaded;
+}

--- a/.claude-plugin/categories.nix
+++ b/.claude-plugin/categories.nix
@@ -9,15 +9,14 @@ let
   categoriesDir = ./categories;
   entries = builtins.readDir categoriesDir;
   isCategoryFile =
-    name: type:
-    type == "regular" && builtins.match ".+\\.nix" name != null && !(builtins.substring 0 1 name == ".");
+    name:
+    entries.${name} == "regular"
+    && builtins.match ".+\\.nix" name != null
+    && builtins.substring 0 1 name != ".";
 
-  categoryFileNames = builtins.attrNames (
-    builtins.foldl' (acc: name: if isCategoryFile name entries.${name} then acc // { ${name} = null; } else acc) { } (
-      builtins.attrNames entries
-    )
+  categoryNames = map (n: builtins.replaceStrings [ ".nix" ] [ "" ] n) (
+    builtins.filter isCategoryFile (builtins.attrNames entries)
   );
-  categoryNames = map (n: builtins.replaceStrings [ ".nix" ] [ "" ] n) categoryFileNames;
 
   loaded = builtins.listToAttrs (
     map (name: {

--- a/.claude-plugin/categories.nix
+++ b/.claude-plugin/categories.nix
@@ -1,35 +1,62 @@
 # Plugin / Skill Categories — entry point.
 # Schema, asymmetry notes, and how-to-add-a-category are in categories.md.
 # Per-category data lives in ./categories/<name>.nix to keep files small.
+#
+# Auto-discovers category files: any *.nix in ./categories/ becomes a category
+# named after the file (without the .nix suffix). To add a category, drop a
+# new file into ./categories/ — no edits needed here.
 let
-  importCategory = name: import ./categories/${name}.nix;
+  categoriesDir = ./categories;
+  entries = builtins.readDir categoriesDir;
+  isCategoryFile =
+    name: type:
+    type == "regular" && builtins.match ".+\\.nix" name != null && !(builtins.substring 0 1 name == ".");
 
-  categoryNames = [
-    "core"
-    "infra"
-    "microsoft-office"
-    "obsidian"
-    "fabric"
-    "browser-automation"
-    "visualization"
-    "huggingface"
-  ];
+  categoryFileNames = builtins.attrNames (
+    builtins.foldl' (acc: name: if isCategoryFile name entries.${name} then acc // { ${name} = null; } else acc) { } (
+      builtins.attrNames entries
+    )
+  );
+  categoryNames = map (n: builtins.replaceStrings [ ".nix" ] [ "" ] n) categoryFileNames;
 
   loaded = builtins.listToAttrs (
     map (name: {
       inherit name;
-      value = importCategory name;
+      value = import (categoriesDir + "/${name}.nix");
     }) categoryNames
   );
-in
-{
-  schemaVersion = 1;
-
-  defaults = builtins.mapAttrs (_: c: c.default) loaded;
 
   members = builtins.mapAttrs (_: c: {
     claudePlugins = c.claudePlugins or [ ];
     skills = c.skills or [ ];
     claudeCommands = c.claudeCommands or [ ];
   }) loaded;
+
+  # Eval-time assertion: no skill or command name appears in two categories.
+  # Catches accidental duplicates that would silently make `skillsToDrop`
+  # over-broad in downstream consumers.
+  allNames = builtins.concatLists (
+    builtins.attrValues (builtins.mapAttrs (_: m: m.skills ++ m.claudeCommands) members)
+  );
+  countOccurrences =
+    needle:
+    builtins.length (builtins.filter (x: x == needle) allNames);
+  duplicates = builtins.foldl' (
+    acc: x: if builtins.elem x acc || countOccurrences x < 2 then acc else acc ++ [ x ]
+  ) [ ] allNames;
+  noDupes =
+    if duplicates == [ ] then
+      true
+    else
+      builtins.throw "categories.nix: skill/command names in multiple categories: ${
+        builtins.concatStringsSep ", " duplicates
+      }";
+in
+assert noDupes;
+{
+  schemaVersion = 1;
+
+  defaults = builtins.mapAttrs (_: c: c.default) loaded;
+
+  inherit members;
 }

--- a/.claude-plugin/categories/browser-automation.nix
+++ b/.claude-plugin/categories/browser-automation.nix
@@ -1,0 +1,20 @@
+# browser-automation — browser-use + playwright.
+# Default OFF. Useful for E2E testing or web scraping; otherwise idle.
+{
+  default = { enabled = false; };
+
+  claudePlugins = [
+    "browser-use@browser-use-skills"
+    "playwright@playwright"
+  ];
+
+  skills = [
+    "browser-use"
+    "cloud"
+    "open-source"
+    "remote-browser"
+    "playwright"
+  ];
+
+  claudeCommands = [ ];
+}

--- a/.claude-plugin/categories/browser-automation.nix
+++ b/.claude-plugin/categories/browser-automation.nix
@@ -5,7 +5,9 @@
 
   claudePlugins = [
     "browser-use@browser-use-skills"
-    "playwright@playwright"
+    # playwright lives under claude-plugins-official's external_plugins/
+    # not in a top-level marketplace named "playwright"
+    "playwright@claude-plugins-official"
   ];
 
   skills = [

--- a/.claude-plugin/categories/core.nix
+++ b/.claude-plugin/categories/core.nix
@@ -1,0 +1,63 @@
+# core — always-on baseline. Git, GitHub, code/project standards, session
+# hygiene. The "what every session needs" category.
+{
+  default = {
+    enabled = true;
+    alwaysOn = true;
+  };
+
+  claudePlugins = [
+    "git-guards@jacobpevans-cc-plugins"
+    "git-workflows@jacobpevans-cc-plugins"
+    "git-standards@jacobpevans-cc-plugins"
+    "github-workflows@jacobpevans-cc-plugins"
+    "code-standards@jacobpevans-cc-plugins"
+    "project-standards@jacobpevans-cc-plugins"
+    "config-management@jacobpevans-cc-plugins"
+    "process-cleanup@jacobpevans-cc-plugins"
+    "pal-health@jacobpevans-cc-plugins"
+    "pr-lifecycle@jacobpevans-cc-plugins"
+    "script-guards@jacobpevans-cc-plugins"
+    "session-analytics@jacobpevans-cc-plugins"
+  ];
+
+  skills = [
+    "agentsmd-authoring"
+    "code-quality-standards"
+    "git-workflow-standards"
+    "gh-cli-patterns"
+    "github-workflow-security-patterns"
+    "infrastructure-standards"
+    "pr-standards"
+    "review-standards"
+    "skills-registry"
+    "sync-permissions"
+    "quick-add-permission"
+    "token-breakdown"
+    "workspace-standards"
+    "writing-rules"
+  ];
+
+  claudeCommands = [
+    "commit-commands-commit"
+    "commit-commands-commit-push-pr"
+    "commit-commands-clean_gone"
+    "git-workflows-sync-main"
+    "git-workflows-troubleshoot-rebase"
+    "git-workflows-troubleshoot-precommit"
+    "git-workflows-troubleshoot-worktree"
+    "git-workflows-wrap-up"
+    "github-workflows-finalize-pr"
+    "github-workflows-ship"
+    "github-workflows-refresh-repo"
+    "github-workflows-rebase-pr"
+    "github-workflows-squash-merge-pr"
+    "github-workflows-resolve-pr-threads"
+    "github-workflows-shape-issues"
+    "github-workflows-trigger-ai-reviews"
+    "config-management-sync-permissions"
+    "config-management-quick-add-permission"
+    "session-analytics-token-breakdown"
+    "codeql-resolver-resolve-codeql"
+  ];
+}

--- a/.claude-plugin/categories/core.nix
+++ b/.claude-plugin/categories/core.nix
@@ -1,5 +1,16 @@
 # core — always-on baseline. Git, GitHub, code/project standards, session
 # hygiene. The "what every session needs" category.
+#
+# Plugin / skill / command split:
+#  * claudePlugins: every plugin this category enables in ~/.claude/settings.json.
+#  * skills: SKILL.md folder names that deploy to ~/.agents/skills/. For
+#    jacobpevans-cc-plugins these are the bare folder names under each
+#    plugin's skills/ directory (no plugin prefix — agent-skills/discoverSkills
+#    uses the bare folder name).
+#  * claudeCommands: synthesized "<plugin>-<command>" skill names. Only
+#    plugins from claude-plugins-official get commands→skills synthesis (via
+#    agent-skills/discoverClaudeCommands), so this list contains only refs
+#    whose owning plugin lives in claude-plugins-official.
 {
   default = {
     enabled = true;
@@ -7,6 +18,7 @@
   };
 
   claudePlugins = [
+    # jacobpevans-cc-plugins
     "git-guards@jacobpevans-cc-plugins"
     "git-workflows@jacobpevans-cc-plugins"
     "git-standards@jacobpevans-cc-plugins"
@@ -19,45 +31,60 @@
     "pr-lifecycle@jacobpevans-cc-plugins"
     "script-guards@jacobpevans-cc-plugins"
     "session-analytics@jacobpevans-cc-plugins"
+    "codeql-resolver@jacobpevans-cc-plugins"
+    # claude-plugins-official — owns commit-commands, whose synthesized
+    # skill names appear in claudeCommands below
+    "commit-commands@claude-plugins-official"
   ];
 
   skills = [
+    # jacobpevans project-standards
     "agentsmd-authoring"
-    "code-quality-standards"
-    "git-workflow-standards"
-    "gh-cli-patterns"
-    "github-workflow-security-patterns"
-    "infrastructure-standards"
-    "pr-standards"
-    "review-standards"
     "skills-registry"
+    "workspace-standards"
+    # jacobpevans code-standards
+    "code-quality-standards"
+    "review-standards"
+    # jacobpevans git-standards
+    "git-workflow-standards"
+    "pr-standards"
+    # jacobpevans github-workflows
+    "gh-cli-patterns"
+    "finalize-pr"
+    "refresh-repo"
+    "rebase-pr"
+    "squash-merge-pr"
+    "resolve-pr-threads"
+    "shape-issues"
+    "ship"
+    "trigger-ai-reviews"
+    # jacobpevans git-workflows
+    "sync-main"
+    "wrap-up"
+    "troubleshoot-precommit"
+    "troubleshoot-rebase"
+    "troubleshoot-worktree"
+    # jacobpevans codeql-resolver
+    "codeql-permission-classification"
+    "github-workflow-security-patterns"
+    # jacobpevans config-management
     "sync-permissions"
     "quick-add-permission"
+    # jacobpevans session-analytics
     "token-breakdown"
-    "workspace-standards"
-    "writing-rules"
+    # jacobpevans content-guards
+    "validate-readme"
+    # jacobpevans infra-standards
+    "infrastructure-standards"
+    # jacobpevans ai-delegation
+    "delegate-to-ai"
+    "auto-maintain"
   ];
 
   claudeCommands = [
+    # commit-commands@claude-plugins-official → discoverClaudeCommands
     "commit-commands-commit"
     "commit-commands-commit-push-pr"
     "commit-commands-clean_gone"
-    "git-workflows-sync-main"
-    "git-workflows-troubleshoot-rebase"
-    "git-workflows-troubleshoot-precommit"
-    "git-workflows-troubleshoot-worktree"
-    "git-workflows-wrap-up"
-    "github-workflows-finalize-pr"
-    "github-workflows-ship"
-    "github-workflows-refresh-repo"
-    "github-workflows-rebase-pr"
-    "github-workflows-squash-merge-pr"
-    "github-workflows-resolve-pr-threads"
-    "github-workflows-shape-issues"
-    "github-workflows-trigger-ai-reviews"
-    "config-management-sync-permissions"
-    "config-management-quick-add-permission"
-    "session-analytics-token-breakdown"
-    "codeql-resolver-resolve-codeql"
   ];
 }

--- a/.claude-plugin/categories/fabric.nix
+++ b/.claude-plugin/categories/fabric.nix
@@ -1,0 +1,48 @@
+# fabric — Daniel Miessler's prompt patterns (analyze_*, extract_*, etc.).
+# Default OFF. Curated subset of 252+ patterns; useful for content analysis
+# but rarely day-to-day code work.
+{
+  default = { enabled = false; };
+
+  claudePlugins = [
+    "fabric-patterns@fabric-patterns"
+  ];
+
+  skills = [
+    "extract_wisdom"
+    "extract_main_idea"
+    "extract_insights"
+    "extract_recommendations"
+    "extract_references"
+    "analyze_paper"
+    "analyze_prose"
+    "analyze_answers"
+    "analyze_logs"
+    "analyze_incident"
+    "analyze_risk"
+    "analyze_comments"
+    "analyze_threat_report"
+    "find_logical_fallacies"
+    "rate_content"
+    "create_prd"
+    "create_design_document"
+    "create_stride_threat_model"
+    "create_threat_scenarios"
+    "create_git_diff_commit"
+    "create_command"
+    "create_summary"
+    "create_coding_feature"
+    "summarize"
+    "summarize_git_changes"
+    "summarize_meeting"
+    "improve_writing"
+    "humanize"
+    "write_pull-request"
+    "write_essay"
+    "review_code"
+    "explain_code"
+    "clean_text"
+  ];
+
+  claudeCommands = [ ];
+}

--- a/.claude-plugin/categories/huggingface.nix
+++ b/.claude-plugin/categories/huggingface.nix
@@ -1,0 +1,27 @@
+# huggingface — HuggingFace Hub CLI + model/dataset/space tooling.
+# Default OFF. Useful for ML work, idle otherwise.
+{
+  default = { enabled = false; };
+
+  claudePlugins = [
+    "huggingface@huggingface-skills"
+  ];
+
+  skills = [
+    "hf-cli"
+    "transformers-js"
+    "huggingface-best"
+    "huggingface-community-evals"
+    "huggingface-datasets"
+    "huggingface-gradio"
+    "huggingface-llm-trainer"
+    "huggingface-local-models"
+    "huggingface-paper-publisher"
+    "huggingface-papers"
+    "huggingface-tool-builder"
+    "huggingface-trackio"
+    "huggingface-vision-trainer"
+  ];
+
+  claudeCommands = [ ];
+}

--- a/.claude-plugin/categories/huggingface.nix
+++ b/.claude-plugin/categories/huggingface.nix
@@ -1,10 +1,26 @@
 # huggingface — HuggingFace Hub CLI + model/dataset/space tooling.
 # Default OFF. Useful for ML work, idle otherwise.
+#
+# The huggingface-skills marketplace contains 13 individual plugins (one per
+# skill). Each plugin's name matches its SKILL.md folder name, so
+# claudePlugins and skills here mirror each other.
 {
   default = { enabled = false; };
 
   claudePlugins = [
-    "huggingface@huggingface-skills"
+    "hf-cli@huggingface-skills"
+    "transformers-js@huggingface-skills"
+    "huggingface-best@huggingface-skills"
+    "huggingface-community-evals@huggingface-skills"
+    "huggingface-datasets@huggingface-skills"
+    "huggingface-gradio@huggingface-skills"
+    "huggingface-llm-trainer@huggingface-skills"
+    "huggingface-local-models@huggingface-skills"
+    "huggingface-paper-publisher@huggingface-skills"
+    "huggingface-papers@huggingface-skills"
+    "huggingface-tool-builder@huggingface-skills"
+    "huggingface-trackio@huggingface-skills"
+    "huggingface-vision-trainer@huggingface-skills"
   ];
 
   skills = [

--- a/.claude-plugin/categories/infra.nix
+++ b/.claude-plugin/categories/infra.nix
@@ -1,0 +1,41 @@
+# infra — Terraform / Ansible / Proxmox / Kubernetes / cloud.
+# Default ON for homelab + cloud DR work.
+{
+  default = { enabled = true; };
+
+  claudePlugins = [
+    "infra-orchestration@jacobpevans-cc-plugins"
+    "infra-standards@jacobpevans-cc-plugins"
+    "ansible-workflows@jacobpevans-cc-plugins"
+    "terraform-module-builder@anthropic-agent-skills"
+    "proxmox-infrastructure@anthropic-agent-skills"
+    "infrastructure-as-code-generator@anthropic-agent-skills"
+  ];
+
+  skills = [
+    "ansible-fundamentals"
+    "ansible-playbook-design"
+    "ansible-role-design"
+    "ansible-idempotency"
+    "ansible-error-handling"
+    "ansible-secrets"
+    "ansible-proxmox"
+    "ansible-testing"
+    "building-terraform-modules"
+    "generating-infrastructure-as-code"
+    "proxmox-infrastructure"
+    "orchestrate-infra"
+    "sync-inventory"
+    "test-e2e"
+  ];
+
+  claudeCommands = [
+    "ansible-workflows-create-playbook"
+    "ansible-workflows-create-role"
+    "ansible-workflows-lint"
+    "ansible-workflows-analyze"
+    "infra-orchestration-orchestrate-infra"
+    "infra-orchestration-sync-inventory"
+    "infra-orchestration-test-e2e"
+  ];
+}

--- a/.claude-plugin/categories/infra.nix
+++ b/.claude-plugin/categories/infra.nix
@@ -1,18 +1,29 @@
 # infra — Terraform / Ansible / Proxmox / Kubernetes / cloud.
 # Default ON for homelab + cloud DR work.
+#
+# Notes on plugin refs:
+#  * ansible-workflows lives in basher83/lunar-claude marketplace, not in
+#    jacobpevans-cc-plugins. The agent-skills auto-discovery picks up its
+#    skills via discoverSkills when lunar-claude is registered as a marketplace.
+#  * terraform/proxmox/iac plugin refs from external marketplaces are not
+#    enumerated here yet — they were aspirational placeholders that didn't
+#    map to verified plugin@marketplace pairs. Add them in a follow-up PR
+#    once their canonical refs are confirmed.
 {
   default = { enabled = true; };
 
   claudePlugins = [
     "infra-orchestration@jacobpevans-cc-plugins"
     "infra-standards@jacobpevans-cc-plugins"
-    "ansible-workflows@jacobpevans-cc-plugins"
-    "terraform-module-builder@anthropic-agent-skills"
-    "proxmox-infrastructure@anthropic-agent-skills"
-    "infrastructure-as-code-generator@anthropic-agent-skills"
+    "ansible-workflows@lunar-claude"
   ];
 
   skills = [
+    # jacobpevans infra-orchestration
+    "orchestrate-infra"
+    "sync-inventory"
+    "test-e2e"
+    # ansible-workflows@lunar-claude (verified deployed names)
     "ansible-fundamentals"
     "ansible-playbook-design"
     "ansible-role-design"
@@ -21,21 +32,13 @@
     "ansible-secrets"
     "ansible-proxmox"
     "ansible-testing"
-    "building-terraform-modules"
-    "generating-infrastructure-as-code"
-    "proxmox-infrastructure"
-    "orchestrate-infra"
-    "sync-inventory"
-    "test-e2e"
   ];
 
   claudeCommands = [
-    "ansible-workflows-create-playbook"
-    "ansible-workflows-create-role"
-    "ansible-workflows-lint"
-    "ansible-workflows-analyze"
-    "infra-orchestration-orchestrate-infra"
-    "infra-orchestration-sync-inventory"
-    "infra-orchestration-test-e2e"
+    # No commands here — neither jacobpevans-cc-plugins nor lunar-claude is
+    # passed to discoverClaudeCommands today. If/when they are, add the
+    # synthesized "<plugin>-<command>" entries (e.g. "ansible-workflows-lint",
+    # "infra-orchestration-orchestrate-infra") and the agent-skills wire-up
+    # in nix-ai will start filtering them.
   ];
 }

--- a/.claude-plugin/categories/microsoft-office.nix
+++ b/.claude-plugin/categories/microsoft-office.nix
@@ -1,0 +1,20 @@
+# microsoft-office — Office document formats (Word/Excel/PowerPoint).
+# Default OFF. Plugin-level loss on Claude side: disabling document-skills
+# also drops pdf/canvas-design/frontend-design/claude-api/mcp-builder/etc.
+# The agentSkills side keeps those because we filter by skill name only.
+# See Phase 2 in the design plan for synthetic-marketplace mitigation.
+{
+  default = { enabled = false; };
+
+  claudePlugins = [
+    "document-skills@anthropic-agent-skills"
+  ];
+
+  skills = [
+    "pptx"
+    "docx"
+    "xlsx"
+  ];
+
+  claudeCommands = [ ];
+}

--- a/.claude-plugin/categories/obsidian.nix
+++ b/.claude-plugin/categories/obsidian.nix
@@ -1,0 +1,23 @@
+# obsidian — Obsidian-specific skills (markdown, bases, canvas, etc.).
+# Default OFF. Useful only when actively editing an Obsidian vault.
+{
+  default = { enabled = false; };
+
+  claudePlugins = [
+    "obsidian@obsidian-skills"
+    "obsidian-visual-skills@axton-obsidian-visual-skills"
+  ];
+
+  skills = [
+    "obsidian-markdown"
+    "obsidian-bases"
+    "obsidian-canvas-creator"
+    "obsidian-cli"
+    "json-canvas"
+    "defuddle"
+    "excalidraw-diagram"
+    "mermaid-visualizer"
+  ];
+
+  claudeCommands = [ ];
+}

--- a/.claude-plugin/categories/visualization.nix
+++ b/.claude-plugin/categories/visualization.nix
@@ -1,0 +1,29 @@
+# visualization — visual-explainer HTML diagram/slide generators.
+# Default OFF. Output-heavy; useful for write-ups, not coding.
+{
+  default = { enabled = false; };
+
+  claudePlugins = [
+    "visual-explainer@visual-explainer-marketplace"
+  ];
+
+  skills = [
+    "generate-web-diagram"
+    "generate-slides"
+    "diff-review"
+    "plan-review"
+    "generate-visual-plan"
+    "project-recap"
+    "fact-check"
+  ];
+
+  claudeCommands = [
+    "visual-explainer-project-recap"
+    "visual-explainer-generate-web-diagram"
+    "visual-explainer-generate-slides"
+    "visual-explainer-diff-review"
+    "visual-explainer-plan-review"
+    "visual-explainer-generate-visual-plan"
+    "visual-explainer-fact-check"
+  ];
+}

--- a/.claude-plugin/categories/visualization.nix
+++ b/.claude-plugin/categories/visualization.nix
@@ -1,5 +1,10 @@
 # visualization — visual-explainer HTML diagram/slide generators.
 # Default OFF. Output-heavy; useful for write-ups, not coding.
+#
+# visual-explainer plugin lives in nicobailon/visual-explainer marketplace
+# which is not in claude-plugins-official. Its commands aren't synthesized to
+# skills today (the plugin isn't passed through discoverClaudeCommands), so
+# claudeCommands is empty pending an agent-skills wire-up update.
 {
   default = { enabled = false; };
 
@@ -17,13 +22,5 @@
     "fact-check"
   ];
 
-  claudeCommands = [
-    "visual-explainer-project-recap"
-    "visual-explainer-generate-web-diagram"
-    "visual-explainer-generate-slides"
-    "visual-explainer-diff-review"
-    "visual-explainer-plan-review"
-    "visual-explainer-generate-visual-plan"
-    "visual-explainer-fact-check"
-  ];
+  claudeCommands = [ ];
 }


### PR DESCRIPTION
## Summary

- Adds `.claude-plugin/categories.nix` (auto-discovering entry point) and per-category files in `.claude-plugin/categories/<name>.nix` declaring plugin/skill categories for both `~/.claude/settings.json` (plugin-level) and `~/.agents/skills/` (skill-level) consumers.
- Adds `.claude-plugin/categories.md` documenting the schema, plugin-vs-skill granularity asymmetry, activation flow, and how to add/rename/remove categories.
- Pure data — no consumers in this PR. Used by follow-up nix-ai and nix-devenv PRs.

## Categories shipped

| Category | Default | Purpose |
| --- | --- | --- |
| `core` | always on | Git, GitHub, code/project standards, session hygiene |
| `infra` | on | Terraform, Ansible, Proxmox, Kubernetes |
| `microsoft-office` | off | document-skills bundle (pptx/docx/xlsx) |
| `obsidian` | off | Obsidian vault skills |
| `fabric` | off | Daniel Miessler's prompt patterns |
| `browser-automation` | off | browser-use + playwright |
| `visualization` | off | visual-explainer HTML output skills |
| `huggingface` | off | HuggingFace Hub CLI + ML tooling |

## Schema correctness guarantees

The entry-point `.claude-plugin/categories.nix`:

- Auto-discovers any `*.nix` file in `./categories/` via `builtins.readDir` — adding a category is a single-file change with no edits to the entry point.
- Asserts at eval time that no skill or command name appears in two categories. Eval fails loudly with `categories.nix: skill/command names in multiple categories: <list>` if a duplicate slips in.

## Why this lives in claude-code-plugins

Both nix-ai and nix-devenv need this mapping and neither owns the upstream marketplaces (anthropics/skills, kepano/obsidian-skills, fabric, etc.). Hosting the canonical list here means one PR to add a new external plugin to a category, not three.

## Asymmetry note (also in categories.md)

Disabling `microsoft-office`:

- **Claude Code** loses pptx + docx + xlsx **plus** pdf, canvas-design, frontend-design, claude-api, mcp-builder, etc. — entire `document-skills` plugin off (plugin-level granularity in `~/.claude/settings.json`).
- **Codex / Gemini** lose **only** pptx, docx, xlsx (skill-level filter on SKILL.md folder names in `~/.agents/skills/`).

If the Claude over-pruning bites, Phase 2 of the design plan (synthetic marketplace splitting) addresses it.

## Test plan

- [x] `nix-instantiate --parse .claude-plugin/categories.nix` — syntax OK
- [x] `nix-instantiate --eval --strict --json .claude-plugin/categories.nix` — full structure evaluates and matches schema, all 8 categories load
- [x] All files under 10 KB (largest is core.nix at ~2.4 KB)
- [x] `pre-commit run --files .claude-plugin/categories.nix .claude-plugin/categories.md .claude-plugin/categories/*.nix` — passes
- [x] CI checks (markdown lint, file size, agent skills validation, CodeQL) — all green
- [x] Eval-time uniqueness assertion verified by hand (no duplicate skill names across categories on disk)
- [x] All 11 review threads from gemini and copilot resolved with code fixes (data integrity in core/infra/browser-automation/huggingface, schema improvements in entry point, docs rewrites in categories.md)

## Follow-ups (not in this PR)

- nix-ai: wire `categories.nix` into `modules/claude/plugins/default.nix` and `modules/agent-skills/default.nix`, expose `programs.claude.plugins.categories.{disabled,enableOnly}` options under `modules/claude/options-content.nix`. Coordination needed with active local branch `feature/karpathy-skills` which rewrites `sharedSkills` discovery.
- nix-devenv: `lib/mk-claude-shell.nix` helper for per-project `.claude/settings.json` overlays via direnv.
- Optional: re-add `terraform-module-builder` / `proxmox-infrastructure` / `infrastructure-as-code-generator` to `infra` category once their canonical `<plugin>@<marketplace>` refs are confirmed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)