### PR TITLE
feat(github-workflows): standardize PR status summary with full URLs and repo-wide view

### DIFF
--- a/github-workflows/skills/finalize-pr/SKILL.md
+++ b/github-workflows/skills/finalize-pr/SKILL.md
@@ -226,9 +226,9 @@ Proceed to Phase 5.
 
 ## Phase 5: Record Result
 
-**Single/current-branch mode**: Emit the **Canonical PR Status Summary** as defined in
-/gh-cli-patterns, titled `PR Status`. Section 1 = this PR. Section 2 = all open PRs in
-the current repo. Then append:
+**Single/current-branch mode**: Emit the **Canonical PR Status Summary** (Section 1 =
+this PR, Section 2 = all open PRs in current repo) as defined in /gh-cli-patterns,
+titled `PR Status`. Then append:
 
 ```text
 IMPORTANT: Do NOT merge this PR. Wait for the human to review and invoke
@@ -252,8 +252,8 @@ If ANY fails, loop back to Phase 2. CRITICAL: CodeQL is SEPARATE from CI — che
 Emit the **Canonical PR Status Summary** as defined in /gh-cli-patterns, titled
 `Finalization Summary`. Section 1 = all PRs processed this run. Section 2 = all open
 PRs in affected repos (current repo for `all` mode; all repos from Phase 1 discovery
-for `org` mode). Show the target repo as a label next to each merge command (not a `--repo` flag —
-`/squash-merge-pr` has no repo argument; the user runs it from the correct worktree).
+for `org` mode). Show the target repo as a label next to each merge command (no `--repo` flag; user
+runs from the correct worktree).
 Wait for explicit user merge commands.
 
 ## Workflow

--- a/github-workflows/skills/finalize-pr/SKILL.md
+++ b/github-workflows/skills/finalize-pr/SKILL.md
@@ -226,12 +226,11 @@ Proceed to Phase 5.
 
 ## Phase 5: Record Result
 
-**Single/current-branch mode**: Report ready status and wait for user:
+**Single/current-branch mode**: Emit the **Canonical PR Status Summary** as defined in
+/gh-cli-patterns, titled `PR Status`. Section 1 = this PR. Section 2 = all open PRs in
+the current repo. Then append:
 
 ```text
-✅ PR #<PR_NUMBER> ready for final review!
-
-All checks passed and PR metadata is up to date.
 IMPORTANT: Do NOT merge this PR. Wait for the human to review and invoke
   /squash-merge-pr    # Squash all commits into one
   /rebase-pr          # Rebase commits onto main (preserves history)
@@ -250,9 +249,11 @@ If ANY fails, loop back to Phase 2. CRITICAL: CodeQL is SEPARATE from CI — che
 
 ## Phase 6: Aggregate Report (Multi-PR Only)
 
-After processing all PRs, emit a summary listing ready PRs with merge commands
-and blocked PRs with reasons. For org-wide mode, include `--repo` on merge
-commands. Wait for explicit user merge commands.
+Emit the **Canonical PR Status Summary** as defined in /gh-cli-patterns, titled
+`Finalization Summary`. Section 1 = all PRs processed this run. Section 2 = all open
+PRs in affected repos (current repo for `all` mode; all repos from Phase 1 discovery
+for `org` mode). For org-wide mode, include `--repo <OWNER>/<REPO>` on merge commands.
+Wait for explicit user merge commands.
 
 ## Workflow
 

--- a/github-workflows/skills/finalize-pr/SKILL.md
+++ b/github-workflows/skills/finalize-pr/SKILL.md
@@ -252,7 +252,8 @@ If ANY fails, loop back to Phase 2. CRITICAL: CodeQL is SEPARATE from CI — che
 Emit the **Canonical PR Status Summary** as defined in /gh-cli-patterns, titled
 `Finalization Summary`. Section 1 = all PRs processed this run. Section 2 = all open
 PRs in affected repos (current repo for `all` mode; all repos from Phase 1 discovery
-for `org` mode). For org-wide mode, include `--repo <OWNER>/<REPO>` on merge commands.
+for `org` mode). Show the target repo as a label next to each merge command (not a `--repo` flag —
+`/squash-merge-pr` has no repo argument; the user runs it from the correct worktree).
 Wait for explicit user merge commands.
 
 ## Workflow

--- a/github-workflows/skills/gh-cli-patterns/SKILL.md
+++ b/github-workflows/skills/gh-cli-patterns/SKILL.md
@@ -216,30 +216,36 @@ Blocked — needs human (2):
 **Title** by invocation:
 
 - `/ship` → `Ship Summary`
-- `/finalize-pr` (single PR or `all`) → `PR Status`
-- `/finalize-pr org` → `Finalization Summary`
+- `/finalize-pr` (single PR or current branch) → `PR Status`
+- `/finalize-pr all` or `/finalize-pr org` → `Finalization Summary`
 
 ### Emoji mapping
 
+Fields are named explicitly — `mergeable` and `mergeStateStatus` are separate fields:
+
 | Emoji | Condition |
 |-------|-----------|
-| ✅ | `mergeStateStatus` is `CLEAN` or `HAS_HOOKS`, no conflicts, no unresolved threads |
-| 🟡 | `BEHIND`, `UNKNOWN` (computing), `UNSTABLE` (checks pending), `REVIEW_REQUIRED`, `COMMENTED` |
-| 🔴 | `DIRTY`/`CONFLICTING` (conflicts), `BLOCKED`, `CHANGES_REQUESTED`, unresolved threads, `isDraft`, CI failed |
+| ✅ | `mergeable == MERGEABLE` AND `mergeStateStatus == CLEAN` or `HAS_HOOKS`, no unresolved threads |
+| 🟡 | `mergeStateStatus == BEHIND`/`UNKNOWN`/`UNSTABLE`, `reviewDecision == REVIEW_REQUIRED`, or `mergeable == UNKNOWN` (GitHub computing) |
+| 🔴 | `mergeable == CONFLICTING`, `mergeStateStatus == BLOCKED`/`DIRTY`/`DRAFT`, `reviewDecision == CHANGES_REQUESTED`, unresolved threads, `isDraft == true`, or CI failed |
 
 ### Status tags
 
 Append after the URL, separated by ` | `. Omit entirely when no issues exist ("Ready for review" suffices).
 
-| Tag | Trigger |
-|-----|---------|
-| `Conflicts` | `mergeable ≠ MERGEABLE` |
-| `N open comments` | Unresolved review thread count > 0 (Section 1: from Phase 3 gate data; Section 2: from `reviewDecision == CHANGES_REQUESTED` or `COMMENTED`) |
-| `CI pending` | `mergeStateStatus` is `UNKNOWN` or `UNSTABLE`, or `statusCheckRollup.state ≠ SUCCESS` |
-| `CI failed` | CI checks have terminal failure state |
-| `CHANGES_REQUESTED` | `reviewDecision == CHANGES_REQUESTED` |
-| `Draft` | `isDraft == true` |
-| `Behind main` | `mergeStateStatus == BEHIND` |
+Tags differ by section because Section 2 uses a lightweight query without per-PR thread counts:
+
+| Tag | Section 1 trigger | Section 2 trigger |
+|-----|-------------------|-------------------|
+| `Conflicts` | `mergeable == CONFLICTING` | `mergeable == CONFLICTING` |
+| `Computing` | `mergeable == UNKNOWN` | `mergeable == UNKNOWN` |
+| `N open comments` | Unresolved thread count from Phase 3 gate | _(not available — omit count)_ |
+| `CHANGES_REQUESTED` | `reviewDecision == CHANGES_REQUESTED` | `reviewDecision == CHANGES_REQUESTED` |
+| `Review required` | `reviewDecision == REVIEW_REQUIRED` | `reviewDecision == REVIEW_REQUIRED` |
+| `CI pending` | `statusCheckRollup.state != SUCCESS` | `mergeStateStatus == UNKNOWN`/`UNSTABLE` |
+| `CI failed` | CI checks terminal failure | `mergeStateStatus == BLOCKED` (when other fields clean) |
+| `Draft` | `isDraft == true` | `isDraft == true` |
+| `Behind main` | `mergeStateStatus == BEHIND` | `mergeStateStatus == BEHIND` |
 
 ### Data queries
 
@@ -249,14 +255,25 @@ Append after the URL, separated by ` | `. Omit entirely when no issues exist ("R
 gh pr view <PR_NUMBER> --json url --jq '.url'
 ```
 
-**Fetch all open PRs** (for Section 2 — one call per affected repo):
+**Fetch all open PRs** (for Section 2 — one GraphQL call per affected repo):
+
+`gh pr list --json` does NOT support `mergeStateStatus` — use GraphQL instead:
 
 ```bash
-gh pr list --state open --limit 50 \
-  --json number,url,title,mergeable,reviewDecision,mergeStateStatus,isDraft
+gh api graphql -f query='
+  query($owner:String!,$repo:String!){
+    repository(owner:$owner,name:$repo){
+      pullRequests(states:OPEN,first:50){
+        nodes{
+          number url title mergeable reviewDecision mergeStateStatus isDraft
+          commits(last:1){nodes{commit{statusCheckRollup{state}}}}
+        }
+      }
+    }
+  }' -f owner=<OWNER> -f repo=<REPO>
 ```
 
-For org-wide mode, add `--repo <OWNER>/<REPO>` per repo from Phase 1 discovery.
+For org-wide mode, run once per repo from Phase 1 discovery, replacing `<OWNER>`/`<REPO>`.
 
 ### "Affected repos" definition
 
@@ -274,8 +291,15 @@ For org-wide mode, add `--repo <OWNER>/<REPO>` per repo from Phase 1 discovery.
 
 ### Merge commands
 
-- Single-repo context: `/squash-merge-pr <NUMBER>   (<OWNER>/<REPO>)`
-- Org-wide mode: `/squash-merge-pr <NUMBER> --repo <OWNER>/<REPO>`
+All modes: `/squash-merge-pr <NUMBER>` — run from the worktree of the target repo.
+The repo context is shown as a label, not a flag (the skill has no `--repo` argument):
+
+```text
+Ready to merge (1):
+  /squash-merge-pr 42   (JacobPEvans/claude-code-plugins)
+```
+
+For org-wide mode, note the target repo so the user knows which worktree to navigate to.
 
 ## Heredoc Body Pattern
 

--- a/github-workflows/skills/gh-cli-patterns/SKILL.md
+++ b/github-workflows/skills/gh-cli-patterns/SKILL.md
@@ -181,6 +181,102 @@ gh api graphql --raw-field 'query=mutation {
 Failure guide: stale `<THREAD_ID>` → re-fetch threads; permission error → `gh auth status`;
 wrong mutation name → check table above.
 
+## Canonical PR Status Summary
+
+Single authoritative format for all PR status output. Reference this section from any
+skill that emits a summary — do NOT define local output formats in individual skills.
+
+### Output format
+
+```text
+{Title}
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+  ✅  https://github.com/<OWNER>/<REPO>/pull/42   Ready for review
+  🟡  https://github.com/<OWNER>/<REPO>/pull/43   CI pending
+  🔴  https://github.com/<OWNER>/<REPO>/pull/44   Conflicts | 3 open comments
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+All Open PRs — <OWNER>/<REPO>
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+  ✅  https://github.com/<OWNER>/<REPO>/pull/42   Ready for review
+  🟡  https://github.com/<OWNER>/<REPO>/pull/43   CI pending
+  🔴  https://github.com/<OWNER>/<REPO>/pull/44   Conflicts | 3 open comments
+  🔴  https://github.com/<OWNER>/<REPO>/pull/50   CHANGES_REQUESTED
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+Ready to merge (1):
+  /squash-merge-pr 42   (<OWNER>/<REPO>)
+
+Blocked — needs human (2):
+  https://github.com/<OWNER>/<REPO>/pull/43 — CI pending
+  https://github.com/<OWNER>/<REPO>/pull/44 — Conflicts | 3 open comments
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+```
+
+**Title** by invocation:
+
+- `/ship` → `Ship Summary`
+- `/finalize-pr` (single PR or `all`) → `PR Status`
+- `/finalize-pr org` → `Finalization Summary`
+
+### Emoji mapping
+
+| Emoji | Condition |
+|-------|-----------|
+| ✅ | `mergeStateStatus` is `CLEAN` or `HAS_HOOKS`, no conflicts, no unresolved threads |
+| 🟡 | `BEHIND`, `UNKNOWN` (computing), `UNSTABLE` (checks pending), `REVIEW_REQUIRED`, `COMMENTED` |
+| 🔴 | `DIRTY`/`CONFLICTING` (conflicts), `BLOCKED`, `CHANGES_REQUESTED`, unresolved threads, `isDraft`, CI failed |
+
+### Status tags
+
+Append after the URL, separated by ` | `. Omit entirely when no issues exist ("Ready for review" suffices).
+
+| Tag | Trigger |
+|-----|---------|
+| `Conflicts` | `mergeable ≠ MERGEABLE` |
+| `N open comments` | Unresolved review thread count > 0 (Section 1: from Phase 3 gate data; Section 2: from `reviewDecision == CHANGES_REQUESTED` or `COMMENTED`) |
+| `CI pending` | `mergeStateStatus` is `UNKNOWN` or `UNSTABLE`, or `statusCheckRollup.state ≠ SUCCESS` |
+| `CI failed` | CI checks have terminal failure state |
+| `CHANGES_REQUESTED` | `reviewDecision == CHANGES_REQUESTED` |
+| `Draft` | `isDraft == true` |
+| `Behind main` | `mergeStateStatus == BEHIND` |
+
+### Data queries
+
+**Fetch PR URL** (for Section 1 — current PRs):
+
+```bash
+gh pr view <PR_NUMBER> --json url --jq '.url'
+```
+
+**Fetch all open PRs** (for Section 2 — one call per affected repo):
+
+```bash
+gh pr list --state open --limit 50 \
+  --json number,url,title,mergeable,reviewDecision,mergeStateStatus,isDraft
+```
+
+For org-wide mode, add `--repo <OWNER>/<REPO>` per repo from Phase 1 discovery.
+
+### "Affected repos" definition
+
+| Invocation | Affected repos for Section 2 |
+|-----------|------------------------------|
+| `/ship` | Current repo |
+| `/finalize-pr` (single or `all`) | Current repo |
+| `/finalize-pr org` | All repos with open PRs from Phase 1 discovery |
+
+### Section 1 vs Section 2
+
+- **Section 1**: Only the PRs targeted by this invocation (the ones being finalized/shipped)
+- **Section 2**: ALL open PRs in every affected repo — including ones completely unrelated to
+  this invocation. This gives a full picture of outstanding work.
+
+### Merge commands
+
+- Single-repo context: `/squash-merge-pr <NUMBER>   (<OWNER>/<REPO>)`
+- Org-wide mode: `/squash-merge-pr <NUMBER> --repo <OWNER>/<REPO>`
+
 ## Heredoc Body Pattern
 
 ```bash

--- a/github-workflows/skills/gh-cli-patterns/SKILL.md
+++ b/github-workflows/skills/gh-cli-patterns/SKILL.md
@@ -201,7 +201,6 @@ All Open PRs — <OWNER>/<REPO>
   ✅  https://github.com/<OWNER>/<REPO>/pull/42   Ready for review
   🟡  https://github.com/<OWNER>/<REPO>/pull/43   CI pending
   🔴  https://github.com/<OWNER>/<REPO>/pull/44   Conflicts | 3 open comments
-  🔴  https://github.com/<OWNER>/<REPO>/pull/50   CHANGES_REQUESTED
 ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
 Ready to merge (1):
@@ -221,8 +220,6 @@ Blocked — needs human (2):
 
 ### Emoji mapping
 
-Fields are named explicitly — `mergeable` and `mergeStateStatus` are separate fields:
-
 | Emoji | Condition |
 |-------|-----------|
 | ✅ | `mergeable == MERGEABLE` AND `mergeStateStatus == CLEAN` or `HAS_HOOKS`, no unresolved threads |
@@ -231,9 +228,7 @@ Fields are named explicitly — `mergeable` and `mergeStateStatus` are separate 
 
 ### Status tags
 
-Append after the URL, separated by ` | `. Omit entirely when no issues exist ("Ready for review" suffices).
-
-Tags differ by section because Section 2 uses a lightweight query without per-PR thread counts:
+Append after the URL, separated by ` | `. Omit when no issues exist ("Ready for review" suffices).
 
 | Tag | Section 1 trigger | Section 2 trigger |
 |-----|-------------------|-------------------|

--- a/github-workflows/skills/ship/SKILL.md
+++ b/github-workflows/skills/ship/SKILL.md
@@ -180,23 +180,15 @@ any `reviewThreads.isResolved` = `false`,
 If any abort condition hits: re-invoke `/finalize-pr <PR_NUMBER>`, wait for completion,
 then re-run both gates. Only list a PR as "Ready to merge" after both gates pass.
 
-Then report:
+Then emit the **Canonical PR Status Summary** as defined in /gh-cli-patterns, titled
+`Ship Summary`. Affected repos = current repo. Fetch each PR's full URL via:
 
-```text
-Ship Summary
-━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
-  ✅  #42  Ready for review
-  ✅  #43  Ready for review
-  ⛔  #44  Blocked — [reason]
-
-Ready to merge (2):
-  /squash-merge-pr 42
-  /squash-merge-pr 43
-
-Blocked — needs human (1):
-  #44 — [detailed reason]
-━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+```bash
+gh pr view <PR_NUMBER> --json url --jq '.url'
 ```
+
+Section 1 lists the PRs targeted by this `/ship` invocation. Section 2 lists all open
+PRs in the current repo (including unrelated ones).
 
 ## Safety
 


### PR DESCRIPTION
## Summary

Establishes a **Canonical PR Status Summary** as the single source of truth for all PR status output across finalization and shipping workflows.

- Define format in `gh-cli-patterns` (URLs, emoji mapping, status tags, merge commands) — no more duplicated inline templates
- Update `ship` and `finalize-pr` to reference it consistently
- Full GitHub PR URLs replace bare `#N` references
- Two-section output: PRs targeted by invocation + all open PRs in affected repos
- Status tags and emoji keyed to actual GraphQL fields (`mergeStateStatus`, `reviewDecision`, `mergeable`)

## Changes

### Key fixes from AI review

- **Title mapping**: `/finalize-pr all`/`org` → `Finalization Summary`; single/current-branch → `PR Status`
- **Emoji mapping**: Explicitly named source fields; separate `mergeable.CONFLICTING` from `mergeStateStatus.DIRTY`
- **Status tags**: Removed invalid `COMMENTED` value; added `Computing` tag; `Conflicts` fires only on `mergeable==CONFLICTING`
- **Section 2 query**: Replaced `gh pr list --json` (missing `mergeStateStatus`) with GraphQL query that includes it
- **Merge commands**: `/squash-merge-pr` has no `--repo` flag — show repo as context label only
- **Thread counts**: Section 2 omits numeric open-comment count (requires per-PR GraphQL; lightweight query can't provide)

## Test plan

- [x] Title mapping per invocation mode
- [x] Emoji/status tag conditions verified against GraphQL schema
- [x] Section 2 GraphQL query includes all required fields
- [x] Merge command format updated (no `--repo` flag)
- [x] Section 1 vs Section 2 field availability documented

Closes #296