### PR TITLE
feat(github-workflows): auto-finalize blockers in squash-merge-pr

### DIFF
--- a/github-workflows/skills/squash-merge-pr/SKILL.md
+++ b/github-workflows/skills/squash-merge-pr/SKILL.md
@@ -1,38 +1,32 @@
 ---
 name: squash-merge-pr
 description: >-
-  Autonomously drive a PR to squash-merge: validates readiness, auto-invokes
-  /finalize-pr to resolve any blockers, then executes the squash merge. Handles
-  single PR from argument or current branch.
+  Squash-merge a PR into main. Invoke only when the user explicitly requests a
+  squash merge. Single PR by number or current branch.
 metadata:
   argument-hint: "[PR_NUMBER]"
 ---
 
 # Squash Merge PR
 
-Autonomous merge pipeline. Validates readiness, invokes `/finalize-pr` automatically
-for common blockers, then executes squash merge. Most blockers (review threads,
-conflicts, CI, CodeQL) are resolved autonomously. Some conditions require human
-action — closed/merged PR, draft PR, unresolvable conflicts, unrecoverable CI, or
-more than 100 review threads needing manual pagination.
+Validates readiness, invokes `/finalize-pr` for soft blocks, then squash-merges.
+Hard stops abort immediately. Some cases require human action: closed/merged PR,
+draft, unresolvable conflicts, unrecoverable CI, or more than 100 review threads.
 
 > **State warning**: Branch state, remote tracking, and PR status change between
 > invocations. Re-run all git/gh commands from Step 1.
 
 ## Critical Rules
 
-- **Never skip validation** — always run the GraphQL check before merging
-- **Never update PR metadata** — that's `/finalize-pr`'s job
-- **Auto-finalize when blocked** — invoke `/finalize-pr` for soft blocks rather than stopping
-- **Hard stops abort immediately** — no finalize attempted; report reason and exit
+- Run the GraphQL readiness gate on every invocation before merging
+- PR metadata updates are `/finalize-pr`'s responsibility
+- Invoke `/finalize-pr` for soft blocks; abort on hard stops with reason
 
 ## Step 1: Validate PR Ready
 
-Run the **canonical PR-readiness gate** from /gh-cli-patterns against
-`<PR_NUMBER>`. Replace `<OWNER>`, `<REPO>`, `<PR_NUMBER>` per the placeholder convention.
-
-Also run the **canonical code-scanning alert count** from /gh-cli-patterns (CodeQL is
-separate from CI and not reflected in `statusCheckRollup`).
+Run the **canonical PR-readiness gate** and **canonical code-scanning alert count**
+from /gh-cli-patterns. Replace `<OWNER>`, `<REPO>`, `<PR_NUMBER>` per the
+placeholder convention. CodeQL is separate from CI — check both.
 
 ### 1.1 Hard stops (abort immediately, no finalize)
 
@@ -58,13 +52,9 @@ full gate. If the gate still fails after finalization, abort with the specific r
 
 ### 1.3 Auto-finalize
 
-Invoke `/finalize-pr <PR_NUMBER>` via the Skill tool and wait for it to complete.
-`/finalize-pr` handles CodeQL, review threads, merge conflicts, CI failures, and
-metadata. If `/finalize-pr` itself reports that human intervention is needed
-(unresolvable conflict, unrecoverable CI failure), abort with its reason.
-
-After `/finalize-pr` completes, re-run the full readiness gate (Steps 1.1 + 1.2). If
-any soft block persists, abort with the specific failing field and reason.
+Invoke `/finalize-pr <PR_NUMBER>`. If it reports human intervention needed, abort with
+its reason. Then re-run the full gate (Steps 1.1 + 1.2); if any soft block persists,
+abort with the specific failing field.
 
 ## Step 2: Generate Squash Commit Message
 

--- a/github-workflows/skills/squash-merge-pr/SKILL.md
+++ b/github-workflows/skills/squash-merge-pr/SKILL.md
@@ -47,14 +47,14 @@ separate from CI and not reflected in `statusCheckRollup`).
 If any of the following fail, proceed to Step 1.3 (auto-finalize), then re-run the
 full gate. If the gate still fails after finalization, abort with the specific reason.
 
-| Check | Must be |
-|-------|---------|
-| `mergeable` | `MERGEABLE` |
-| `mergeStateStatus` | `CLEAN` or `HAS_HOOKS` |
-| `reviewDecision` | `APPROVED` or `null` |
-| `statusCheckRollup.state` | `SUCCESS` |
-| All `reviewThreads.isResolved` | `true` |
-| CodeQL alert count | `0` |
+| Check | Must be | Abort message (if still failing after finalize) |
+|-------|---------|------------------------------------------------|
+| `mergeable` | `MERGEABLE` | "PR has git conflicts — unresolvable" |
+| `mergeStateStatus` | `CLEAN` or `HAS_HOOKS` | "PR merge state is {value} — still blocked after finalize" |
+| `reviewDecision` | `APPROVED` or `null` | "Review decision is {value}" |
+| `statusCheckRollup.state` | `SUCCESS` | "CI is {state} — unrecoverable" |
+| All `reviewThreads.isResolved` | `true` | "Unresolved review threads remain" |
+| CodeQL alert count | `0` | "Open CodeQL alerts remain — run /resolve-codeql manually" |
 
 ### 1.3 Auto-finalize
 

--- a/github-workflows/skills/squash-merge-pr/SKILL.md
+++ b/github-workflows/skills/squash-merge-pr/SKILL.md
@@ -10,9 +10,11 @@ metadata:
 
 # Squash Merge PR
 
-Fully autonomous merge pipeline. Validates readiness, invokes `/finalize-pr`
-automatically when blockers are found, then executes squash merge. The only
-conditions that require human action are: PR is closed/merged, or PR is in draft.
+Autonomous merge pipeline. Validates readiness, invokes `/finalize-pr` automatically
+for common blockers, then executes squash merge. Most blockers (review threads,
+conflicts, CI, CodeQL) are resolved autonomously. Some conditions require human
+action — closed/merged PR, draft PR, unresolvable conflicts, unrecoverable CI, or
+more than 100 review threads needing manual pagination.
 
 > **State warning**: Branch state, remote tracking, and PR status change between
 > invocations. Re-run all git/gh commands from Step 1.
@@ -21,40 +23,45 @@ conditions that require human action are: PR is closed/merged, or PR is in draft
 
 - **Never skip validation** — always run the GraphQL check before merging
 - **Never update PR metadata** — that's `/finalize-pr`'s job
-- **Auto-finalize when blocked** — invoke `/finalize-pr` rather than stopping
-- **Two hard stops only** — `state != OPEN` and `isDraft == true` abort without finalize
+- **Auto-finalize when blocked** — invoke `/finalize-pr` for soft blocks rather than stopping
+- **Hard stops abort immediately** — no finalize attempted; report reason and exit
 
 ## Step 1: Validate PR Ready
 
 Run the **canonical PR-readiness gate** from /gh-cli-patterns against
 `<PR_NUMBER>`. Replace `<OWNER>`, `<REPO>`, `<PR_NUMBER>` per the placeholder convention.
 
+Also run the **canonical code-scanning alert count** from /gh-cli-patterns (CodeQL is
+separate from CI and not reflected in `statusCheckRollup`).
+
 ### 1.1 Hard stops (abort immediately, no finalize)
 
-| Field | Abort condition | Message |
-|-------|-----------------|---------|
-| `state` | `!= OPEN` | "PR is closed or merged — nothing to do" |
-| `isDraft` | `true` | "PR is a draft — mark it ready for review first" |
+| Condition | Message |
+|-----------|---------|
+| `state != OPEN` | "PR is closed or merged — nothing to do" |
+| `isDraft == true` | "PR is a draft — mark it ready for review first" |
+| `reviewThreads.pageInfo.hasNextPage == true` | ">100 review threads — paginate manually and re-verify before merging" |
 
 ### 1.2 Soft blocks (invoke /finalize-pr, then re-verify)
 
 If any of the following fail, proceed to Step 1.3 (auto-finalize), then re-run the
 full gate. If the gate still fails after finalization, abort with the specific reason.
 
-| Field | Must be |
+| Check | Must be |
 |-------|---------|
 | `mergeable` | `MERGEABLE` |
 | `mergeStateStatus` | `CLEAN` or `HAS_HOOKS` |
 | `reviewDecision` | `APPROVED` or `null` |
 | `statusCheckRollup.state` | `SUCCESS` |
 | All `reviewThreads.isResolved` | `true` |
-| `reviewThreads.pageInfo.hasNextPage` | `false` |
+| CodeQL alert count | `0` |
 
 ### 1.3 Auto-finalize
 
 Invoke `/finalize-pr <PR_NUMBER>` via the Skill tool and wait for it to complete.
 `/finalize-pr` handles CodeQL, review threads, merge conflicts, CI failures, and
-metadata — everything needed to reach a mergeable state.
+metadata. If `/finalize-pr` itself reports that human intervention is needed
+(unresolvable conflict, unrecoverable CI failure), abort with its reason.
 
 After `/finalize-pr` completes, re-run the full readiness gate (Steps 1.1 + 1.2). If
 any soft block persists, abort with the specific failing field and reason.

--- a/github-workflows/skills/squash-merge-pr/SKILL.md
+++ b/github-workflows/skills/squash-merge-pr/SKILL.md
@@ -1,46 +1,63 @@
 ---
 name: squash-merge-pr
 description: >-
-  Validate PR merge-readiness and squash merge into main. Errors if PR is not
-  ready — use /finalize-pr first to fix issues. Use after /finalize-pr reports
-  ready. Handles single PR from argument or current branch.
+  Autonomously drive a PR to squash-merge: validates readiness, auto-invokes
+  /finalize-pr to resolve any blockers, then executes the squash merge. Handles
+  single PR from argument or current branch.
 metadata:
   argument-hint: "[PR_NUMBER]"
 ---
 
 # Squash Merge PR
 
-Validates PR readiness and executes squash merge. If the PR is not ready,
-errors immediately and suggests `/finalize-pr` to fix issues. Never fixes
-issues — only merges.
+Fully autonomous merge pipeline. Validates readiness, invokes `/finalize-pr`
+automatically when blockers are found, then executes squash merge. The only
+conditions that require human action are: PR is closed/merged, or PR is in draft.
 
 > **State warning**: Branch state, remote tracking, and PR status change between
 > invocations. Re-run all git/gh commands from Step 1.
 
 ## Critical Rules
 
-- **Never fix issues** — only merge. If PR isn't ready, error and suggest `/finalize-pr`
-- **Never update PR metadata** — that's `/finalize-pr`'s job
 - **Never skip validation** — always run the GraphQL check before merging
+- **Never update PR metadata** — that's `/finalize-pr`'s job
+- **Auto-finalize when blocked** — invoke `/finalize-pr` rather than stopping
+- **Two hard stops only** — `state != OPEN` and `isDraft == true` abort without finalize
 
 ## Step 1: Validate PR Ready
 
 Run the **canonical PR-readiness gate** from /gh-cli-patterns against
 `<PR_NUMBER>`. Replace `<OWNER>`, `<REPO>`, `<PR_NUMBER>` per the placeholder convention.
 
-If any check fails, abort immediately with the field's failure message and
-append: `— run /finalize-pr to fix`.
+### 1.1 Hard stops (abort immediately, no finalize)
 
-| Field | Must be | Abort message |
-|-------|---------|---------------|
-| `state` | `OPEN` | "PR is not open — run `/finalize-pr` to fix" |
-| `mergeable` | `MERGEABLE` | "PR has merge conflicts — run `/finalize-pr` to fix" |
-| `mergeStateStatus` | `CLEAN` or `HAS_HOOKS` | "PR merge state is {value} — run `/finalize-pr` to fix" |
-| `isDraft` | `false` | "PR is a draft — mark ready first, then run `/finalize-pr`" |
-| `reviewDecision` | `APPROVED` or `null` | "PR needs approval — run `/finalize-pr` to fix" |
-| `statusCheckRollup.state` | `SUCCESS` | "CI is not passing: {state} — run `/finalize-pr` to fix" |
-| All `reviewThreads.isResolved` | `true` | "Unresolved review threads — run `/finalize-pr` to fix" |
-| `reviewThreads.pageInfo.hasNextPage` | `false` | ">100 threads — paginate and re-verify" |
+| Field | Abort condition | Message |
+|-------|-----------------|---------|
+| `state` | `!= OPEN` | "PR is closed or merged — nothing to do" |
+| `isDraft` | `true` | "PR is a draft — mark it ready for review first" |
+
+### 1.2 Soft blocks (invoke /finalize-pr, then re-verify)
+
+If any of the following fail, proceed to Step 1.3 (auto-finalize), then re-run the
+full gate. If the gate still fails after finalization, abort with the specific reason.
+
+| Field | Must be |
+|-------|---------|
+| `mergeable` | `MERGEABLE` |
+| `mergeStateStatus` | `CLEAN` or `HAS_HOOKS` |
+| `reviewDecision` | `APPROVED` or `null` |
+| `statusCheckRollup.state` | `SUCCESS` |
+| All `reviewThreads.isResolved` | `true` |
+| `reviewThreads.pageInfo.hasNextPage` | `false` |
+
+### 1.3 Auto-finalize
+
+Invoke `/finalize-pr <PR_NUMBER>` via the Skill tool and wait for it to complete.
+`/finalize-pr` handles CodeQL, review threads, merge conflicts, CI failures, and
+metadata — everything needed to reach a mergeable state.
+
+After `/finalize-pr` completes, re-run the full readiness gate (Steps 1.1 + 1.2). If
+any soft block persists, abort with the specific failing field and reason.
 
 ## Step 2: Generate Squash Commit Message
 
@@ -115,7 +132,7 @@ git worktree prune
 
 ## Integration
 
-Invoke after `/finalize-pr` reports ready:
+Invoke at any time — auto-finalizes if needed:
 
 ```text
 /squash-merge-pr          # Current branch PR
@@ -124,7 +141,7 @@ Invoke after `/finalize-pr` reports ready:
 
 ## Related Skills
 
-- finalize-pr (github-workflows) — drives PR to mergeable state before squash-merge-pr is invoked
+- finalize-pr (github-workflows) — invoked automatically by squash-merge-pr when blockers are found
 - rebase-pr (github-workflows) — alternative merge strategy that preserves commit history
 - pr-standards (git-standards) — PR authoring and review standards
 - gh-cli-patterns (github-workflows) — canonical gh CLI command shapes, placeholder convention, PR-readiness gate


### PR DESCRIPTION
## Summary

- `squash-merge-pr` now autonomously invokes `/finalize-pr` when it finds blockers instead of stopping and asking the user to do it manually
- Two-tier gate: hard stops (closed/draft PR, >100 threads) abort immediately; soft blocks (threads, conflicts, CI, CodeQL) trigger auto-finalize then re-verify
- After `/finalize-pr` completes, the readiness gate re-runs — if it still fails, abort with the specific reason
- Updated skill description, integration section, and related-skills note to reflect autonomous merge behavior

## Changes

- Rewrote step 1 of readiness validation into explicit hard stops vs. soft blocks
- Added Step 1.3 for auto-finalize invocation with clear fallback logic
- Updated `Critical Rules` section to reflect new autonomy model
- Clarified abort messages for each failure scenario
- Updated integration docs to say "invoke at any time" instead of "invoke after /finalize-pr reports ready"

## Test Plan

- [ ] Run `/squash-merge-pr` on a PR with unresolved review threads — verify auto-finalize and merge
- [ ] Run `/squash-merge-pr` on a ready PR — verify it skips finalize and merges directly  
- [ ] Run `/squash-merge-pr` on a draft PR — verify hard-stop abort without calling `/finalize-pr`
- [ ] Run `/squash-merge-pr` on a closed PR — verify hard-stop abort with appropriate message

## Related

- Closes #<issue-number> (if applicable)
- Related to PR #297 (canonical PR status summary for finalize-pr)

Generated with Claude Code