### PR TITLE
🤖 Fix #20: feat: create agent-teams-guard hook plugin for team safety

### DIFF
--- a/agent-teams-guard/.claude-plugin/plugin.json
+++ b/agent-teams-guard/.claude-plugin/plugin.json
@@ -1,0 +1,9 @@
+{
+  "name": "agent-teams-guard",
+  "version": "1.0.0",
+  "description": "Safety guardrails for Agent Teams: detects orphaned sessions on startup and warns with remediation steps",
+  "author": {"name": "JacobPEvans"},
+  "homepage": "https://github.com/JacobPEvans/claude-code-plugins",
+  "keywords": ["hooks", "agent-teams", "guard", "safety", "session-cleanup"],
+  "license": "Apache-2.0"
+}

--- a/agent-teams-guard/README.md
+++ b/agent-teams-guard/README.md
@@ -1,0 +1,55 @@
+# agent-teams-guard
+
+Safety guardrails for Agent Teams: detects orphaned sessions on startup and warns with cleanup guidance.
+
+## Purpose
+
+Agent Teams can leave behind stale resources when a session ends unexpectedly:
+
+- Orphaned `~/.claude/teams/*/config.json` entries where the team lead process is gone
+- No signal to the user that cleanup is needed before starting a new session
+
+This plugin adds a `SessionStart` hook that checks for these on every session open and prints
+a warning to stderr with the exact `rm -rf` command needed to clean up.
+
+## Components
+
+### SessionStart: Orphaned Session Guard
+
+On every session start, scans `~/.claude/teams/*/config.json` for stale team entries.
+A stale entry is one where a `pid` file exists but the process is no longer alive.
+
+**Behavior:**
+
+- Gracefully no-ops when `~/.claude/teams/` does not exist (teams never enabled or already clean)
+- Warns to stderr with the team session path and a remediation command
+- Does **not** auto-delete — lets the user confirm before removing state
+- Timeout: 10 seconds
+
+**Example warning output (stderr):**
+
+```
+WARNING: Stale Agent Team session.
+Path: /home/user/.claude/teams/team-abc123
+Cleanup: rm -rf /home/user/.claude/teams/team-abc123
+```
+
+## Future Components
+
+**File Conflict Guard** (`PreToolUse: Write|Edit`) — checks whether another teammate is
+currently editing the same file and blocks conflicting edits with a clear message.
+Tracking: see issue [#20](https://github.com/JacobPEvans/claude-code-plugins/issues/20).
+
+**Token Budget Guard** — tracks cumulative tokens per teammate and warns before budget
+exhaustion. Requires API access to token counts; deferred to a future version.
+
+## Graceful Degradation
+
+When Agent Teams are not enabled or `~/.claude/teams/` is absent, the `SessionStart`
+hook exits silently (zero output, zero side-effects). This plugin is safe to install
+even if teams are never used.
+
+## Dependencies
+
+Related: [agent-teams-orchestrator (#15)](https://github.com/JacobPEvans/claude-code-plugins/issues/15)
+for team lifecycle management and config format documentation.

--- a/agent-teams-guard/hooks/hooks.json
+++ b/agent-teams-guard/hooks/hooks.json
@@ -1,0 +1,16 @@
+{
+  "hooks": {
+    "SessionStart": [
+      {
+        "matcher": "*",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "bash -c 'TEAMS=$HOME/.claude/teams; test -d $TEAMS || exit 0; for c in $TEAMS/*/config.json; do test -f $c || continue; p=${c%config.json}pid; test -f $p || continue; pid=$(cat $p 2>/dev/null); kill -0 $pid 2>/dev/null || printf \"\\nWARNING: Stale Agent Team session.\\nPath: %s\\nCleanup: rm -rf %s\\n\" \"${c%/config.json}\" \"${c%/config.json}\" >&2; done'",
+            "timeout": 10
+          }
+        ]
+      }
+    ]
+  }
+}


### PR DESCRIPTION
Closes #20

## Problem

Agent Teams can leave behind stale resources when a session ends unexpectedly —
`~/.claude/teams/*/config.json` entries whose team lead process is no longer alive.
Without any guardrail, users get no signal that cleanup is needed before starting
a new session.

## Approach

Create `agent-teams-guard` as a **hooks-only plugin** (no executable scripts required)
with a single `SessionStart` hook. On every session open, an inline bash command scans
`~/.claude/teams/*/config.json` entries, checks whether each `pid` file references a
live process, and warns to stderr with the exact `rm -rf` command if a stale entry is found.

The plugin is intentionally minimal (v1 scope: orphaned session detection only).
The file-conflict guard (`PreToolUse: Write|Edit`) requires executable Python scripts
and is left as a follow-up in the issue.

## Files changed

- `agent-teams-guard/.claude-plugin/plugin.json` — plugin manifest (hooks-only; cclint skips hooks-only plugins)
- `agent-teams-guard/hooks/hooks.json` — `SessionStart` hook with inline bash orphan-detection command
- `agent-teams-guard/README.md` — usage docs and future-work roadmap

## CI status

passed — `validate` check completed successfully (JSON validation + schema check pass;
cclint skips hooks-only plugins; no executable scripts to check)

## Self-review

This PR was drafted by Issue Solver and is opened as a DRAFT for human review before merge.
The Hard Rules in the prompt enforce: signed commits via Contents API, no dependency changes,
no infra/workflow edits, secret-pattern pre-flight scan.

---

Generated by Issue Solver — prompt source: <https://github.com/JacobPEvans/claude-code-routines/blob/main/routines/issue-solver.prompt.md>
