### PR TITLE
feat(refresh-repo): auto-restore main worktree to main branch

### DIFF
--- a/github-workflows/skills/refresh-repo/SKILL.md
+++ b/github-workflows/skills/refresh-repo/SKILL.md
@@ -57,23 +57,30 @@ Replace `<OWNER>`, `<REPO>`, `<PR_NUMBER>` per the placeholder legend in that sk
    convention in `~/git/CLAUDE.md`, `<repo>/main/` (or `<repo>/master/`) must always
    be checked out to the default branch. After a feature PR merges, that worktree is
    often left on the now-`[gone]` feature branch. Detect and fix:
-   - Resolve the default worktree path from `git worktree list` — the entry whose
-     path basename matches the default branch (e.g. `<repo>/main` for `main`).
-   - If that path exists and `git -C <path> symbolic-ref --short HEAD` does not equal
-     `<default>`:
+   - Resolve the default worktree path using the workspace convention:
+     `~/git/<repo>/<default>/`. Do not rely on basename matching from
+     `git worktree list` — a feature branch named `feature/<default>` would also
+     produce a path basename of `<default>`.
+   - If that path exists and `git -C <path> rev-parse --abbrev-ref HEAD` does not equal
+     `<default>` (this is safer than `symbolic-ref --short HEAD`, which errors on
+     detached HEAD during a rebase or commit-checkout):
      - If the worktree has uncommitted changes
        (`git -C <path> status --porcelain` is non-empty), stash them first with
        `git -C <path> stash push -u -m "refresh-repo: auto-stash before <default> restore"`
        and surface the stash reference in the summary so the user can recover.
      - `git -C <path> checkout <default>`.
    - Never use `--force`, never discard uncommitted work, never reset.
-5. Sync the default branch from its existing worktree with a fast-forward only merge:
-   `git merge --ff-only origin/<default>`.
+5. Sync the default branch from its dedicated worktree with a fast-forward only merge,
+   using `git -C <path>` so the merge always targets the default worktree regardless
+   of the current shell directory:
+   `git -C <path> merge --ff-only origin/<default>`.
    If the default worktree is dirty or divergent, report it and skip instead of resetting.
 6. Delete local branches already merged into the default branch with `git branch -d`.
    Never delete main/master/develop/current branches, worktree-checked-out branches, or branches
    with open PRs.
-7. Switch back to the original branch if it still exists.
+7. Conclude the operation without switching branches. Because Steps 4 and 5 used
+   `git -C <path>` to operate on the default worktree directly, the current shell's
+   working directory and branch were never changed — each worktree owns its checkout.
 
 Do not use `git fetch --tags`, `git fetch --prune-tags`, or `git pull --tags` during the
 normal refresh. Tags are audited separately in Step 4 so local-only non-release tags and

--- a/github-workflows/skills/refresh-repo/SKILL.md
+++ b/github-workflows/skills/refresh-repo/SKILL.md
@@ -53,13 +53,27 @@ Replace `<OWNER>`, `<REPO>`, `<PR_NUMBER>` per the placeholder legend in that sk
 2. Fetch origin with stale remote branch pruning, but without tag updates:
    `git fetch origin --no-tags --prune --force`
 3. Determine the default branch from `origin/HEAD`, falling back to `main` or `master`.
-4. Sync the default branch from its existing worktree with a fast-forward only merge:
+4. **Restore the default-branch worktree to the default branch.** Per the workspace
+   convention in `~/git/CLAUDE.md`, `<repo>/main/` (or `<repo>/master/`) must always
+   be checked out to the default branch. After a feature PR merges, that worktree is
+   often left on the now-`[gone]` feature branch. Detect and fix:
+   - Resolve the default worktree path from `git worktree list` — the entry whose
+     path basename matches the default branch (e.g. `<repo>/main` for `main`).
+   - If that path exists and `git -C <path> symbolic-ref --short HEAD` does not equal
+     `<default>`:
+     - If the worktree has uncommitted changes
+       (`git -C <path> status --porcelain` is non-empty), stash them first with
+       `git -C <path> stash push -u -m "refresh-repo: auto-stash before <default> restore"`
+       and surface the stash reference in the summary so the user can recover.
+     - `git -C <path> checkout <default>`.
+   - Never use `--force`, never discard uncommitted work, never reset.
+5. Sync the default branch from its existing worktree with a fast-forward only merge:
    `git merge --ff-only origin/<default>`.
    If the default worktree is dirty or divergent, report it and skip instead of resetting.
-5. Delete local branches already merged into the default branch with `git branch -d`.
+6. Delete local branches already merged into the default branch with `git branch -d`.
    Never delete main/master/develop/current branches, worktree-checked-out branches, or branches
    with open PRs.
-6. Switch back to the original branch if it still exists.
+7. Switch back to the original branch if it still exists.
 
 Do not use `git fetch --tags`, `git fetch --prune-tags`, or `git pull --tags` during the
 normal refresh. Tags are audited separately in Step 4 so local-only non-release tags and
@@ -118,7 +132,8 @@ Finish with `git worktree prune`.
 ### 6. Summary
 
 Report: PRs assessed as merge-ready (if any), tags deleted or reported, branches cleaned up,
-worktrees removed, current branch, and sync status.
+worktrees removed, default-branch worktree restorations (with any stash references created),
+current branch, and sync status.
 
 ## Common Mistake to Avoid
 


### PR DESCRIPTION
## Summary

Adds a step to the `refresh-repo` Sync Workflow that detects and fixes a
common workspace drift: the `<repo>/main/` worktree left checked out to a
now-`[gone]` feature branch after that branch's PR merged.

This violates the convention in `~/git/CLAUDE.md`:

> Main worktree always at `~/git/<repo>/main/` on the `main` branch.

A workspace sweep observed this drift in four repos: `docs`,
`dryvist-dotgithub`, `dryvist-dotgithub-tofu`, and `tf-splunk-aws`.

## Behavior

In Step 3 (Sync Workflow), immediately after the default-branch is
resolved and before the fast-forward merge:

- Resolve the default-branch worktree path from `git worktree list`.
- If `git -C <path> symbolic-ref --short HEAD` is not the default branch:
  - If the worktree has uncommitted changes (`git status --porcelain`
    is non-empty), stash them with a recoverable label
    (`refresh-repo: auto-stash before <default> restore`) and surface
    the stash ref in the summary.
  - `git -C <path> checkout <default>`.
- Never `--force`, never reset, never discard uncommitted work.

The existing fast-forward merge now runs on the restored default branch
instead of failing or no-op'ing on the wrong head.

## Test plan

- [ ] Manually drop `<repo>/main/` onto a `[gone]` feature branch and
      run `/refresh-repo`; verify it stashes (if dirty), checks out
      `main`, and fast-forwards.
- [ ] Run `/refresh-repo` on a repo where `<repo>/main/` is already on
      `main` and verify no-op behavior (no extra stash, no unnecessary
      checkout).
- [ ] Run on a repo with a dirty `main/` worktree on a feature branch
      and confirm the stash reference is reported.