### PR TITLE
feat(skills): add workspace sweep + purge-pr + workaround rubric

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -15,11 +15,11 @@ This is a **Claude Code plugins repository** containing production-ready hooks f
 | **config-management** | Skill | `/sync-permissions`, `/quick-add-permission` | Manage Claude and Gemini permission configs across repositories |
 | **content-guards** | Pre/PostToolUse | Bash, Write, Edit | Token limits, markdown/README validation, webfetch guard, issue/PR rate limiting, branch limits |
 | **git-guards** | PreToolUse | Bash, Edit, Write, NotebookEdit | Blocks dangerous git/gh commands and file edits on main branch |
-| **git-workflows** | Command/Skill | `/sync-main`, `/wrap-up`, `/troubleshoot-rebase`, `/troubleshoot-precommit`, `/troubleshoot-worktree` | Local git sync, troubleshooting, and post-merge cleanup |
-| **github-workflows** | Command/Skill | `/ship`, `/finalize-pr`, `/refresh-repo`, `/rebase-pr`, `/squash-merge-pr`, `/resolve-pr-threads`, `/gh-cli-patterns`, `/shape-issues`, `/trigger-ai-reviews` | GitHub PR/issue management workflows |
+| **git-workflows** | Command/Skill | `/sync-main`, `/wrap-up` (incl. `purge-pr` mode), `/troubleshoot-rebase`, `/troubleshoot-precommit`, `/troubleshoot-worktree` | Local git sync, troubleshooting, post-merge cleanup, and atomic PR-close + branch purge |
+| **github-workflows** | Command/Skill | `/ship`, `/finalize-pr`, `/refresh-repo` (incl. `--sweep` and `--prune-stale` modes), `/rebase-pr`, `/squash-merge-pr`, `/resolve-pr-threads`, `/gh-cli-patterns`, `/shape-issues`, `/trigger-ai-reviews` | GitHub PR/issue management workflows plus cross-repo workspace sweep and stale-branch pruning |
 | **infra-orchestration** | Skill | `/orchestrate-infra`, `/sync-inventory`, `/test-e2e` | Cross-repo infrastructure orchestration for Terraform and Ansible |
 | **code-standards** | Skill | `/code-quality-standards`, `/review-standards` | Code quality standards, documentation formatting, testing philosophy, and review guidelines |
-| **git-standards** | Skill | `/git-workflow-standards`, `/pr-standards` | Git workflow standards, branch hygiene, PR creation guards, and issue linking |
+| **git-standards** | Skill | `/git-workflow-standards`, `/pr-standards` | Git workflow standards, branch hygiene, PR creation guards, workaround vs fix classification, and issue linking |
 | **infra-standards** | Skill | `/infrastructure-standards` | Infrastructure standards for Proxmox, Terraform, Ansible including deployment pipeline and secrets management |
 | **pal-health** | SessionStart | — | Warns on session start if PAL MCP had a recent Doppler auth failure |
 | **pr-lifecycle** | PostToolUse | Bash | Automatically triggers `/finalize-pr` after `gh pr create` succeeds |

--- a/git-standards/skills/pr-standards/SKILL.md
+++ b/git-standards/skills/pr-standards/SKILL.md
@@ -43,6 +43,33 @@ git log origin/main..HEAD --oneline
 
 If empty: no new work. Clean up instead.
 
+## Workaround Classification
+
+When reviewing a PR, distinguish a real fix from a workaround. Workarounds
+become permanent tech debt if merged without acknowledgement. Four red flags:
+
+1. **No upstream issue cited**: PR body does not name a specific upstream
+   bug, version, or repository where the underlying problem lives.
+2. **Phantom remediation mechanism**: PR body claims an automated "sync
+   workflow", "auto-update", or "re-trigger" mechanism — verify with
+   `grep -r <name> .` in the repo; if zero matches, the mechanism does not
+   exist and the inline copy will drift silently.
+3. **Asymmetric application**: the change is local to 1 of N similar
+   consumers of a shared pattern (e.g. inlines 1 of 6 cross-repo imports),
+   with no written rationale for the asymmetry.
+4. **No exit criterion**: PR does not name the condition under which this
+   workaround can be removed (upstream version, infrastructure change,
+   deprecation date).
+
+**Three or more red flags → recommend close, not merge.** Workarounds get an
+upstream issue and an exit criterion before merging, or they are rejected.
+
+Origin: 2026-05-22 `ansible-splunk` PRs #216 (asymmetric inline of 1 of 6
+imports, references non-existent `gh-aw-sync-upstream` mechanism) and #218
+(cron-retrigger band-aid with no exit criterion). Both reached
+`mergeStateStatus: CLEAN` and would have merged under a mechanical-gate
+review.
+
 ## Issue-PR Bidirectional Linking
 
 Every PR body must include (bot PRs exempt):

--- a/git-workflows/skills/wrap-up/SKILL.md
+++ b/git-workflows/skills/wrap-up/SKILL.md
@@ -117,10 +117,16 @@ abandoned work) and you want the local trace gone in one operation.
 
 Sequence:
 
-1. `gh pr close <PR_NUMBER> --repo <owner>/<repo> --comment "<reason>" --delete-branch`
-2. Resolve the branch's local worktree path from `git worktree list`. If
-   present, `git worktree remove <path> --force`.
-3. `git branch -D <branch>` to delete the local branch.
+1. **Capture the branch name first** — step 2 deletes the remote ref, so
+   capture before that runs:
+   `gh pr view <PR_NUMBER> --repo <owner>/<repo> --json headRefName --jq '.headRefName'`.
+2. Close the PR and delete the remote branch in one call:
+   `gh pr close <PR_NUMBER> --repo <owner>/<repo> --comment "<reason>" --delete-branch`.
+3. If the current worktree IS the captured branch's, `git switch main`
+   first so step 4 can remove it.
+4. Find the worktree path via `git worktree list` matching the captured
+   branch, then `git worktree remove <path> --force` if present, and
+   `git branch -D <branch>`.
 
 Closes the gap where `gh pr close --delete-branch` removes only the remote
 branch and leaves the local branch + worktree behind. Reuses the

--- a/git-workflows/skills/wrap-up/SKILL.md
+++ b/git-workflows/skills/wrap-up/SKILL.md
@@ -108,10 +108,31 @@ Session Issues Log:
 
 If no follow-up items are found, state that explicitly — do not fabricate work.
 
+## Focused Mode: Purge a Specific PR
+
+Invoke as `/wrap-up purge-pr <PR_NUMBER>` to close one PR and atomically
+purge all local state for its branch. Skips Steps 1–4 above. Use when you
+know a PR should be closed (obsolete duplicate, workaround anti-pattern,
+abandoned work) and you want the local trace gone in one operation.
+
+Sequence:
+
+1. `gh pr close <PR_NUMBER> --repo <owner>/<repo> --comment "<reason>" --delete-branch`
+2. Resolve the branch's local worktree path from `git worktree list`. If
+   present, `git worktree remove <path> --force`.
+3. `git branch -D <branch>` to delete the local branch.
+
+Closes the gap where `gh pr close --delete-branch` removes only the remote
+branch and leaves the local branch + worktree behind. Reuses the
+worktree-removal command shape from `/troubleshoot-worktree` and aligns with
+`/clean_gone`'s post-removal state.
+
 ## Related Skills
 
-- **refresh-repo** (github-workflows) — PR readiness check + repo sync + worktree cleanup (Step 1 dependency)
+- **refresh-repo** (github-workflows) — PR readiness check + repo sync + worktree cleanup (Step 1 dependency); also provides `--sweep` and `--prune-stale` modes
 - **shape-issues** (github-workflows) — Shape and create well-structured GitHub issues
+- **troubleshoot-worktree** (git-workflows) — Worktree-removal command shape reused by `purge-pr` mode
+- **pr-standards** (git-standards) — Workaround Classification rubric used to decide when `purge-pr` is the right action
 
 ## Summary
 

--- a/github-workflows/skills/refresh-repo/SKILL.md
+++ b/github-workflows/skills/refresh-repo/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: refresh-repo
-description: Check PR merge readiness, sync local repo, and cleanup stale worktrees
+description: Check PR merge readiness, sync local repo, cleanup stale worktrees; optional cross-repo sweep and stale-branch prune modes
 ---
 
 <!-- cspell:words refspec oneline headRefOid mergedAt -->
@@ -119,6 +119,50 @@ Finish with `git worktree prune`.
 
 Report: PRs assessed as merge-ready (if any), tags deleted or reported, branches cleaned up,
 worktrees removed, current branch, and sync status.
+
+## Cross-Repo Operating Modes
+
+Optional modes that change `/refresh-repo` from single-repo to workspace-wide.
+Both modes reuse the stale-worktree definition from Step 5 and the deletion
+rules from Step 5.7 — they only add new pre-filters, never weaken existing
+safety.
+
+### `--sweep [<repo-glob>]`
+
+Multi-repo cleanup of abandoned local branches. For each repo matching the
+glob (default `~/git/<owner>/*/main/`), for every local branch where
+`git log origin/main..HEAD` is non-empty:
+
+1. **Content-equivalence check**: compute merge base, diff each touched file
+   against current `origin/main`. If every touched file is content-equivalent
+   to (or older than) `origin/main`, delete the branch and its worktree.
+   Already-on-main contributions do not deserve a PR.
+2. **Workaround filter**: if the diff (a) modifies 1 of N files sharing a
+   common shape with no written rationale for the asymmetry, or (b) references
+   a "sync mechanism" / "auto-update" by name that `grep -r <name> .` returns
+   zero matches for, surface for human review. Do not open a draft.
+3. Only branches passing both checks become draft PRs.
+4. Per-repo summary: branches deleted as content-equivalent, branches surfaced
+   for review, branches PR-ified, branches unchanged.
+
+**Origin**: the 2026-05-22 sweep opened 8 dead PRs against `ansible-splunk`
+(6 already-on-main duplicates, 2 workaround anti-patterns). Both filters
+above would have caught all 8 before any CI ran.
+
+### `--prune-stale <days>` (default 60)
+
+Delete local branches with no open PR and no push activity within `<days>`.
+Expands Step 5's stale definition with a time threshold; still respects every
+safety rule (never delete branches with open PRs, uncommitted changes, or
+the current checkout).
+
+Per branch: if `gh pr list --head <branch>` is empty AND
+`git log -1 --format=%cr <branch>` is older than `<days>`, run
+`git worktree remove <path>` (per Step 5 — never `--force`) then
+`git branch -d <branch>`.
+
+Use `--prune-stale 30` for an aggressive sweep, `--prune-stale 90` for
+conservative.
 
 ## Common Mistake to Avoid
 


### PR DESCRIPTION
## Summary

Prevent the 2026-05-22 sweep failure mode (8 dead PRs against `ansible-splunk`: 6 already-on-main duplicates, 2 workaround anti-patterns) by extending three existing skills. **No new skills created** — DRY audit of all 17 plugins confirmed each piece fits cleanly into an existing skill.

## Changes

### `/refresh-repo` — two new operating modes

- **`--sweep [<repo-glob>]`** (multi-repo): for every local branch where `git log origin/main..HEAD` is non-empty, run a content-equivalence check (delete the branch + worktree if every touched file matches main) plus a workaround filter (asymmetric application to a multi-consumer pattern, or named "sync mechanism" that `grep -r` returns 0 matches for → surface for human review). Only novel branches become draft PRs. Would have caught all 8 dead `ansible-splunk` PRs before any CI ran.
- **`--prune-stale <days>`** (default 60): delete local branches with no open PR and no push activity within the window. Builds on the existing stale-worktree definition without weakening any safety rule.

### `/wrap-up` — focused `purge-pr` sub-action

Invoke as `/wrap-up purge-pr <N>` to close one PR and atomically remove its local branch + worktree. Closes the gap where `gh pr close --delete-branch` removes only the remote branch and leaves local debris.

### `/pr-standards` — Workaround Classification rubric

Four red flags for distinguishing a real fix from a workaround:
1. No upstream issue cited
2. Phantom remediation mechanism (claimed but does not exist in repo)
3. Asymmetric application across consumers of a shared pattern
4. No exit criterion

Three or more red flags → recommend close, not merge.

### `AGENTS.md`

Updated rows for `git-workflows`, `github-workflows`, and `git-standards` to describe the new behaviours. No new rows.

## DRY audit

Initial draft proposed 5 new skills. Audit across all 17 jacobpevans-cc-plugins and the ai-assistant-instructions rules found every piece fits inside an existing skill. Net result: **5 file edits, 0 new skills, 0 new plugins**.

## Companion PR

Companion rule update at JacobPEvans/ai-assistant-instructions adds two rows to the Ecosystem alternatives table pointing future sessions at these new modes.

## Test Plan

- [x] `pre-commit run --files <changed-files>` passes locally
- [ ] After merge: run `/refresh-repo --sweep` against current `~/git/JacobPEvans/*/` workspace; expect zero new PRs from dead branches (ansible-splunk's 8 are already gone, others should also be sane)
- [ ] After merge: create synthetic test PR, invoke `/wrap-up purge-pr <N>`, confirm branch + worktree + remote all gone
- [ ] After merge: re-evaluate closed PRs ansible-splunk#216 and #218 against the new Workaround Classification rubric; expect both to score 3+ red flags

## Related Issues

None — internal tooling improvement driven by the 2026-05-22 ansible-splunk sweep retrospective.