### PR TITLE
chore: drop URL output requirement from PR status summary

### DIFF
--- a/github-workflows/skills/gh-cli-patterns/SKILL.md
+++ b/github-workflows/skills/gh-cli-patterns/SKILL.md
@@ -191,24 +191,24 @@ skill that emits a summary — do NOT define local output formats in individual 
 ```text
 {Title}
 ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
-  ✅  https://github.com/<OWNER>/<REPO>/pull/42   Ready for review
-  🟡  https://github.com/<OWNER>/<REPO>/pull/43   CI pending
-  🔴  https://github.com/<OWNER>/<REPO>/pull/44   Conflicts | 3 open comments
+  ✅  #42   Ready for review
+  🟡  #43   CI pending
+  🔴  #44   Conflicts | 3 open comments
 ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
 All Open PRs — <OWNER>/<REPO>
 ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
-  ✅  https://github.com/<OWNER>/<REPO>/pull/42   Ready for review
-  🟡  https://github.com/<OWNER>/<REPO>/pull/43   CI pending
-  🔴  https://github.com/<OWNER>/<REPO>/pull/44   Conflicts | 3 open comments
+  ✅  #42   Ready for review
+  🟡  #43   CI pending
+  🔴  #44   Conflicts | 3 open comments
 ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
 Ready to merge (1):
   /squash-merge-pr 42   (<OWNER>/<REPO>)
 
 Blocked — needs human (2):
-  https://github.com/<OWNER>/<REPO>/pull/43 — CI pending
-  https://github.com/<OWNER>/<REPO>/pull/44 — Conflicts | 3 open comments
+  #43 — CI pending
+  #44 — Conflicts | 3 open comments
 ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 ```
 
@@ -228,7 +228,7 @@ Blocked — needs human (2):
 
 ### Status tags
 
-Append after the URL, separated by ` | `. Omit when no issues exist ("Ready for review" suffices).
+Append after the PR number, separated by ` | `. Omit when no issues exist ("Ready for review" suffices).
 
 | Tag | Section 1 trigger | Section 2 trigger |
 |-----|-------------------|-------------------|
@@ -244,12 +244,6 @@ Append after the URL, separated by ` | `. Omit when no issues exist ("Ready for 
 
 ### Data queries
 
-**Fetch PR URL** (for Section 1 — current PRs):
-
-```bash
-gh pr view <PR_NUMBER> --json url --jq '.url'
-```
-
 **Fetch all open PRs** (for Section 2 — one GraphQL call per affected repo):
 
 `gh pr list --json` does NOT support `mergeStateStatus` — use GraphQL instead:
@@ -260,7 +254,7 @@ gh api graphql -f query='
     repository(owner:$owner,name:$repo){
       pullRequests(states:OPEN,first:50){
         nodes{
-          number url title mergeable reviewDecision mergeStateStatus isDraft
+          number title mergeable reviewDecision mergeStateStatus isDraft
           commits(last:1){nodes{commit{statusCheckRollup{state}}}}
         }
       }

--- a/github-workflows/skills/ship/SKILL.md
+++ b/github-workflows/skills/ship/SKILL.md
@@ -181,11 +181,7 @@ If any abort condition hits: re-invoke `/finalize-pr <PR_NUMBER>`, wait for comp
 then re-run both gates. Only list a PR as "Ready to merge" after both gates pass.
 
 Then emit the **Canonical PR Status Summary** as defined in /gh-cli-patterns, titled
-`Ship Summary`. Affected repos = current repo. Fetch each PR's full URL via:
-
-```bash
-gh pr view <PR_NUMBER> --json url --jq '.url'
-```
+`Ship Summary`. Affected repos = current repo.
 
 Section 1 lists the PRs targeted by this `/ship` invocation. Section 2 lists all open
 PRs in the current repo (including unrelated ones).


### PR DESCRIPTION
## Summary

- `#42` style refs are already clickable in Ghostty / Claude Code, so the full `https://github.com/<OWNER>/<REPO>/pull/N` URL in every PR status summary was redundant noise.
- Remove URL output from all three sections of the Canonical PR Status Summary in `gh-cli-patterns`; PRs are now identified by `#N`.
- Drop the "Fetch PR URL" subsection and the matching `gh pr view ... --json url` block in `/ship`.
- Strip the now-unused `url` field from the open-PR GraphQL query.

Pure removal — no new instructions, no format additions beyond the `#N` ref the user explicitly named as the replacement.

## Test plan

- [ ] `/ship` and `/finalize-pr` summaries render with `#N` refs and remain clickable in Ghostty
- [ ] No remaining `https://github.com/<OWNER>/<REPO>/pull/` placeholders in `github-workflows/skills/`