### PR TITLE
docs: use ${GIT_HOME_PUBLIC} path var across plugin docs and skills

### DIFF
--- a/.claude/rules/worktree-conventions.md
+++ b/.claude/rules/worktree-conventions.md
@@ -10,13 +10,13 @@ default `.worktrees/` placement.
 ## Path Convention
 
 ```text
-~/git/{repo-name}/{branch-name}/
+${GIT_HOME_PUBLIC}/{repo-name}/{branch-name}/
 ```
 
 Examples:
 
-- `~/git/claude-code-plugins/feat/add-readme-validation/`
-- `~/git/terraform-proxmox/fix/firewall-rules/`
+- `${GIT_HOME_PUBLIC}/claude-code-plugins/feat/add-readme-validation/`
+- `${GIT_HOME_PUBLIC}/terraform-proxmox/fix/firewall-rules/`
 
 ## Branch Naming
 
@@ -26,7 +26,7 @@ Examples:
 
 ## Before Creating
 
-1. Switch to main and sync: `cd ~/git/{repo-name}/main && git switch main && git pull`
+1. Switch to main and sync: `cd ${GIT_HOME_PUBLIC}/{repo-name}/main && git switch main && git pull`
 2. Clean stale worktrees — a worktree is stale when it has no open PR, no uncommitted changes, and either:
    - A merged PR whose `headRefOid` matches local `HEAD` (`gh pr list --state merged --head {branch} --json number,headRefOid,mergedAt`)
    - A deleted remote (`[gone]` in `git branch -vv`) with no commits ahead of default

--- a/codeql-resolver/README.md
+++ b/codeql-resolver/README.md
@@ -150,7 +150,7 @@ codeql-resolver/
 ### Example 1: Fix ci-gate.yml Permissions
 
 ```bash
-cd ~/git/ai-assistant-instructions
+cd ${GIT_HOME_PUBLIC}/ai-assistant-instructions
 /resolve-codeql file:.github/workflows/ci-gate.yml
 ```
 
@@ -233,7 +233,7 @@ All fixes follow these security principles:
 ### Local Testing
 
 ```bash
-cd ~/git/claude-code-plugins/feature/codeql-resolver/codeql-resolver
+cd ${GIT_HOME_PUBLIC}/claude-code-plugins/feature/codeql-resolver/codeql-resolver
 python3 scripts/test_codeql_plugin.py
 ```
 

--- a/git-standards/skills/git-workflow-standards/SKILL.md
+++ b/git-standards/skills/git-workflow-standards/SKILL.md
@@ -10,7 +10,7 @@ description: Use when managing branches, resolving merge conflicts, syncing with
 All development MUST use dedicated worktrees. Never work directly on main.
 
 ```text
-~/git/<repo>/
+${GIT_HOME_PUBLIC}/<repo>/
 ├── .git/                    # Shared bare repo
 ├── main/                    # Main branch (read-only for dev)
 ├── feature/<branch-name>/   # Feature worktrees
@@ -22,15 +22,15 @@ All development MUST use dedicated worktrees. Never work directly on main.
 
 | Branch Type | Branch Name | Worktree Path |
 | --- | --- | --- |
-| Main | `main` | `~/git/<repo>/main/` |
-| Feature | `feature/add-feature` | `~/git/<repo>/feature/add-feature/` |
-| Bugfix | `bugfix/bug-name` | `~/git/<repo>/bugfix/bug-name/` |
-| Hotfix | `hotfix/critical-issue` | `~/git/<repo>/hotfix/critical-issue/` |
-| Release | `release/1.2.0` | `~/git/<repo>/release/1.2.0/` |
-| Chore | `chore/dependency-updates` | `~/git/<repo>/chore/dependency-updates/` |
+| Main | `main` | `${GIT_HOME_PUBLIC}/<repo>/main/` |
+| Feature | `feature/add-feature` | `${GIT_HOME_PUBLIC}/<repo>/feature/add-feature/` |
+| Bugfix | `bugfix/bug-name` | `${GIT_HOME_PUBLIC}/<repo>/bugfix/bug-name/` |
+| Hotfix | `hotfix/critical-issue` | `${GIT_HOME_PUBLIC}/<repo>/hotfix/critical-issue/` |
+| Release | `release/1.2.0` | `${GIT_HOME_PUBLIC}/<repo>/release/1.2.0/` |
+| Chore | `chore/dependency-updates` | `${GIT_HOME_PUBLIC}/<repo>/chore/dependency-updates/` |
 
-Create: `git worktree add -b <branch> ~/git/<repo>/<branch> main`
-Remove: `git worktree remove ~/git/<repo>/<branch>`
+Create: `git worktree add -b <branch> ${GIT_HOME_PUBLIC}/<repo>/<branch> main`
+Remove: `git worktree remove ${GIT_HOME_PUBLIC}/<repo>/<branch>`
 
 Every branch with commits MUST have an associated PR.
 Orphaned branches must get a PR or be deleted.
@@ -44,7 +44,7 @@ worktrees with uncommitted changes are NEVER stale. Use `git worktree remove` (n
 
 ## Branch Hygiene
 
-- Sync main daily: `cd ~/git/<repo>/main && git pull`
+- Sync main daily: `cd ${GIT_HOME_PUBLIC}/<repo>/main && git pull`
 - Long-running branches: rebase from main weekly
 - Before PRs: ensure branch is on latest main
 - Never branch from feature branches — always from main
@@ -58,8 +58,8 @@ worktrees with uncommitted changes are NEVER stale. Use `git worktree remove` (n
 Sync main workflow:
 
 ```bash
-cd ~/git/<repo>/main && git fetch origin main && git pull origin main
-cd ~/git/<repo>/feature/<branch> && git merge origin/main --no-edit
+cd ${GIT_HOME_PUBLIC}/<repo>/main && git fetch origin main && git pull origin main
+cd ${GIT_HOME_PUBLIC}/<repo>/feature/<branch> && git merge origin/main --no-edit
 ```
 
 ## Merge Conflict Resolution

--- a/git-workflows/skills/sync-main/SKILL.md
+++ b/git-workflows/skills/sync-main/SKILL.md
@@ -26,7 +26,7 @@ or all open PR branches when using the `all` parameter.
 
 1. **Verify state**: `git branch --show-current`, `git status --porcelain`
    - STOP if on main or uncommitted changes
-2. **Find and sync main**: `cd ~/git/<repo>/main && git fetch --all --prune --force && git pull`
+2. **Find and sync main**: `cd ${GIT_HOME_PUBLIC}/<repo>/main && git fetch --all --prune --force && git pull`
 3. **Check for updates**: `git fetch origin --force main`
 4. **Report**: Show commits behind with `git log --oneline HEAD..origin/main` (informational only)
 5. **Merge**: `git merge origin/main --no-edit`

--- a/git-workflows/skills/troubleshoot-worktree/SKILL.md
+++ b/git-workflows/skills/troubleshoot-worktree/SKILL.md
@@ -46,14 +46,14 @@ Means TWO things named `origin/main`:
 ### Main Worktree Not Found
 
 ```bash
-git worktree add ~/git/<repo>/main main
+git worktree add ${GIT_HOME_PUBLIC}/<repo>/main main
 ```
 
 ### Branch Worktree Not Found
 
 ```bash
 git fetch origin --force <branch>
-git worktree add ~/git/<repo>/<branch> <branch>
+git worktree add ${GIT_HOME_PUBLIC}/<repo>/<branch> <branch>
 ```
 
 ### Branch Not Found

--- a/github-workflows/skills/rebase-pr/SKILL.md
+++ b/github-workflows/skills/rebase-pr/SKILL.md
@@ -72,7 +72,7 @@ that skill.
 ## Step 2: Sync Main
 
 ```bash
-cd ~/git/{repo}/main
+cd ${GIT_HOME_PUBLIC}/{repo}/main
 git fetch origin --force main
 git pull origin main
 ```
@@ -90,8 +90,8 @@ git branch {branch} origin/{branch}
 Create worktree and rebase:
 
 ```bash
-git worktree add ~/git/{repo}/{worktree-path} {branch}
-cd ~/git/{repo}/{worktree-path}
+git worktree add ${GIT_HOME_PUBLIC}/{repo}/{worktree-path} {branch}
+cd ${GIT_HOME_PUBLIC}/{repo}/{worktree-path}
 git rebase origin/main
 git log --oneline origin/main..HEAD   # verify commits are ahead
 ```
@@ -117,7 +117,7 @@ git push --force-with-lease origin {branch}
 ## Step 5: Fast-Forward Merge to Main
 
 ```bash
-cd ~/git/{repo}/main
+cd ${GIT_HOME_PUBLIC}/{repo}/main
 git merge-base --is-ancestor origin/main {branch}  # verify FF is possible; exit 0 = yes
 git merge --ff-only {branch}
 ```
@@ -146,7 +146,7 @@ gh pr view <PR_NUMBER> --json state --jq '.state'   # expect: MERGED
 ## Step 7: Cleanup
 
 ```bash
-git worktree remove ~/git/{repo}/{worktree-path}
+git worktree remove ${GIT_HOME_PUBLIC}/{repo}/{worktree-path}
 git branch -d {branch}              # use -D only after confirming state=MERGED
 git push origin --delete {branch}
 git worktree prune

--- a/github-workflows/skills/refresh-repo/SKILL.md
+++ b/github-workflows/skills/refresh-repo/SKILL.md
@@ -54,11 +54,11 @@ Replace `<OWNER>`, `<REPO>`, `<PR_NUMBER>` per the placeholder legend in that sk
    `git fetch origin --no-tags --prune --force`
 3. Determine the default branch from `origin/HEAD`, falling back to `main` or `master`.
 4. **Restore the default-branch worktree to the default branch.** Per the workspace
-   convention in `~/git/CLAUDE.md`, `<repo>/main/` (or `<repo>/master/`) must always
+   convention in `${GIT_HOME}/CLAUDE.md`, `<repo>/main/` (or `<repo>/master/`) must always
    be checked out to the default branch. After a feature PR merges, that worktree is
    often left on the now-`[gone]` feature branch. Detect and fix:
    - Resolve the default worktree path using the workspace convention:
-     `~/git/<repo>/<default>/`. Do not rely on basename matching from
+     `${GIT_HOME_PUBLIC}/<repo>/<default>/`. Do not rely on basename matching from
      `git worktree list` — a feature branch named `feature/<default>` would also
      produce a path basename of `<default>`.
    - If that path exists and `git -C <path> rev-parse --abbrev-ref HEAD` does not equal
@@ -152,7 +152,7 @@ safety.
 ### `--sweep [<repo-glob>]`
 
 Multi-repo cleanup of abandoned local branches. For each repo matching the
-glob (default `~/git/<owner>/*/main/`), for every local branch where
+glob (default `${GIT_HOME_PUBLIC}/*/main/`), for every local branch where
 `git log origin/main..HEAD` is non-empty:
 
 1. **Content-equivalence check**: compute merge base, diff each touched file

--- a/infra-orchestration/skills/orchestrate-infra/SKILL.md
+++ b/infra-orchestration/skills/orchestrate-infra/SKILL.md
@@ -39,7 +39,7 @@ Full pipeline validation: validate, plan, export inventory, syntax-check, check,
 
 ## Execution Pattern
 
-1. **Resolve repo paths**: All repos at `~/git/<repo-name>/main/`
+1. **Resolve repo paths**: All repos at `${GIT_HOME_PUBLIC}/<repo-name>/main/`
 2. **Dispatch Terraform phase**: Launch subagent for terraform-proxmox operations
 3. **Await completion**: Terraform must complete before Ansible phases
 4. **Dispatch Ansible phases**: Launch parallel subagents for independent Ansible repos (invoke `superpowers:dispatching-parallel-agents`)

--- a/infra-orchestration/skills/sync-inventory/SKILL.md
+++ b/infra-orchestration/skills/sync-inventory/SKILL.md
@@ -18,7 +18,7 @@ Export Terraform outputs as Ansible inventory and distribute the generated inven
 ### 1. Export Terraform Inventory
 
 ```bash
-cd ~/git/terraform-proxmox/main
+cd ${GIT_HOME_PUBLIC}/terraform-proxmox/main
 doppler run -- terragrunt output -json ansible_inventory
 ```
 
@@ -30,9 +30,9 @@ Convert Terraform JSON output to Ansible inventory YAML format with host groups,
 
 Copy the generated inventory to:
 
-- `~/git/ansible-proxmox/main/inventory/`
-- `~/git/ansible-proxmox-apps/main/inventory/`
-- `~/git/ansible-splunk/main/inventory/`
+- `${GIT_HOME_PUBLIC}/ansible-proxmox/main/inventory/`
+- `${GIT_HOME_PUBLIC}/ansible-proxmox-apps/main/inventory/`
+- `${GIT_HOME_PUBLIC}/ansible-splunk/main/inventory/`
 
 ### 4. Validate
 
@@ -42,7 +42,7 @@ Run `ansible-inventory --list -i inventory/hosts.yml` in each target repo to con
 
 - Terraform state must exist (run `terragrunt apply` first)
 - Doppler configured with `iac-conf-mgmt` project
-- All target Ansible repos must be checked out at `~/git/<repo>/main/`
+- All target Ansible repos must be checked out at `${GIT_HOME_PUBLIC}/<repo>/main/`
 
 ## Error Handling
 

--- a/infra-orchestration/skills/test-e2e/SKILL.md
+++ b/infra-orchestration/skills/test-e2e/SKILL.md
@@ -13,14 +13,14 @@ Validates syntax, plans changes, exports inventory, and dry-runs Ansible playboo
 ### Stage 1: Terraform Validate
 
 ```bash
-cd ~/git/terraform-proxmox/main
+cd ${GIT_HOME_PUBLIC}/terraform-proxmox/main
 doppler run -- terragrunt validate
 ```
 
 ### Stage 2: Terraform Plan
 
 ```bash
-cd ~/git/terraform-proxmox/main
+cd ${GIT_HOME_PUBLIC}/terraform-proxmox/main
 doppler run -- terragrunt plan
 ```
 


### PR DESCRIPTION
## Summary

Sweep hardcoded `~/git/...` references in plugin skills, rules, and READMEs to use the `${GIT_HOME_PUBLIC}` workspace variable introduced in nix-home v1.23.0.

## Why

Many skills here (`/sync-main`, `/refresh-repo`, `/troubleshoot-worktree`, `/orchestrate-infra`, `/sync-inventory`, etc.) show path templates that consumers read and adapt. Pre-migration these templates baked in `~/git/<repo>/...` — post-migration the public/private workspace split is a first-class part of the conventions, and the templates should model it.

## Files (10)

- `.claude/rules/worktree-conventions.md`
- `codeql-resolver/README.md`
- `git-standards/skills/git-workflow-standards/SKILL.md`
- `git-workflows/skills/sync-main/SKILL.md`
- `git-workflows/skills/troubleshoot-worktree/SKILL.md`
- `github-workflows/skills/rebase-pr/SKILL.md`
- `github-workflows/skills/refresh-repo/SKILL.md`
- `infra-orchestration/skills/orchestrate-infra/SKILL.md`
- `infra-orchestration/skills/sync-inventory/SKILL.md`
- `infra-orchestration/skills/test-e2e/SKILL.md`

37 hardcoded path occurrences → 37 variable references.

## Test plan

- [x] No remaining `~/git/` refs in tracked `*.md` / `*.sh` / `*.yml` / `*.yaml` (verified via grep)
- [x] Pre-commit hooks pass

## Related

- nix-home v1.23.0 introducing `GIT_HOME` / `GIT_HOME_PUBLIC` sessionVariables
- Sibling sweep PRs in nix-darwin, nix-home, ai-assistant-instructions, orbstack-kubernetes

Assisted-by: Claude <noreply@anthropic.com>