### PR TITLE
docs: drop workspace-path assumption from plugin docs and skills

### DIFF
--- a/.claude/rules/worktree-conventions.md
+++ b/.claude/rules/worktree-conventions.md
@@ -9,14 +9,13 @@ default `.worktrees/` placement.
 
 ## Path Convention
 
-```text
-${GIT_HOME_PUBLIC}/{repo-name}/{branch-name}/
-```
+Per repo: main at `<repo>/main/`, every feature worktree as a sibling at
+`<repo>/{branch-name}/`. Siblings are reachable as `../{branch-name}/`.
 
 Examples:
 
-- `${GIT_HOME_PUBLIC}/claude-code-plugins/feat/add-readme-validation/`
-- `${GIT_HOME_PUBLIC}/terraform-proxmox/fix/firewall-rules/`
+- `claude-code-plugins/feat/add-readme-validation/`
+- `terraform-proxmox/fix/firewall-rules/`
 
 ## Branch Naming
 
@@ -26,7 +25,7 @@ Examples:
 
 ## Before Creating
 
-1. Switch to main and sync: `cd ${GIT_HOME_PUBLIC}/{repo-name}/main && git switch main && git pull`
+1. Sync main: `git pull`
 2. Clean stale worktrees — a worktree is stale when it has no open PR, no uncommitted changes, and either:
    - A merged PR whose `headRefOid` matches local `HEAD` (`gh pr list --state merged --head {branch} --json number,headRefOid,mergedAt`)
    - A deleted remote (`[gone]` in `git branch -vv`) with no commits ahead of default

--- a/codeql-resolver/README.md
+++ b/codeql-resolver/README.md
@@ -149,8 +149,9 @@ codeql-resolver/
 
 ### Example 1: Fix ci-gate.yml Permissions
 
+In `ai-assistant-instructions`:
+
 ```bash
-cd ${GIT_HOME_PUBLIC}/ai-assistant-instructions
 /resolve-codeql file:.github/workflows/ci-gate.yml
 ```
 
@@ -233,8 +234,7 @@ All fixes follow these security principles:
 ### Local Testing
 
 ```bash
-cd ${GIT_HOME_PUBLIC}/claude-code-plugins/feature/codeql-resolver/codeql-resolver
-python3 scripts/test_codeql_plugin.py
+python3 codeql-resolver/scripts/test_codeql_plugin.py
 ```
 
 ### Adding New Alert Types

--- a/git-standards/skills/git-workflow-standards/SKILL.md
+++ b/git-standards/skills/git-workflow-standards/SKILL.md
@@ -7,30 +7,21 @@ description: Use when managing branches, resolving merge conflicts, syncing with
 
 ## Worktree Structure
 
-All development MUST use dedicated worktrees. Never work directly on main.
+All development uses dedicated worktrees. Never work directly on main.
 
 ```text
-${GIT_HOME_PUBLIC}/<repo>/
+<repo>/
 ├── .git/                    # Shared bare repo
-├── main/                    # Main branch (read-only for dev)
-├── feature/<branch-name>/   # Feature worktrees
-├── bugfix/<branch-name>/    # Bugfix worktrees
-├── hotfix/<branch-name>/    # Hotfix worktrees
-├── release/<branch-name>/   # Release worktrees
-└── chore/<branch-name>/     # Chore worktrees
+├── main/                    # Main branch
+├── feature/<branch-name>/
+├── bugfix/<branch-name>/
+├── hotfix/<branch-name>/
+├── release/<branch-name>/
+└── chore/<branch-name>/
 ```
 
-| Branch Type | Branch Name | Worktree Path |
-| --- | --- | --- |
-| Main | `main` | `${GIT_HOME_PUBLIC}/<repo>/main/` |
-| Feature | `feature/add-feature` | `${GIT_HOME_PUBLIC}/<repo>/feature/add-feature/` |
-| Bugfix | `bugfix/bug-name` | `${GIT_HOME_PUBLIC}/<repo>/bugfix/bug-name/` |
-| Hotfix | `hotfix/critical-issue` | `${GIT_HOME_PUBLIC}/<repo>/hotfix/critical-issue/` |
-| Release | `release/1.2.0` | `${GIT_HOME_PUBLIC}/<repo>/release/1.2.0/` |
-| Chore | `chore/dependency-updates` | `${GIT_HOME_PUBLIC}/<repo>/chore/dependency-updates/` |
-
-Create: `git worktree add -b <branch> ${GIT_HOME_PUBLIC}/<repo>/<branch> main`
-Remove: `git worktree remove ${GIT_HOME_PUBLIC}/<repo>/<branch>`
+Create: `git worktree add -b <branch> ../<branch> main`
+Remove: `git worktree remove ../<branch>`
 
 Every branch with commits MUST have an associated PR.
 Orphaned branches must get a PR or be deleted.
@@ -44,7 +35,7 @@ worktrees with uncommitted changes are NEVER stale. Use `git worktree remove` (n
 
 ## Branch Hygiene
 
-- Sync main daily: `cd ${GIT_HOME_PUBLIC}/<repo>/main && git pull`
+- Sync main daily: `git pull`
 - Long-running branches: rebase from main weekly
 - Before PRs: ensure branch is on latest main
 - Never branch from feature branches — always from main
@@ -58,8 +49,8 @@ worktrees with uncommitted changes are NEVER stale. Use `git worktree remove` (n
 Sync main workflow:
 
 ```bash
-cd ${GIT_HOME_PUBLIC}/<repo>/main && git fetch origin main && git pull origin main
-cd ${GIT_HOME_PUBLIC}/<repo>/feature/<branch> && git merge origin/main --no-edit
+git fetch origin main && git pull origin main   # in main
+git merge origin/main --no-edit                 # in the feature worktree
 ```
 
 ## Merge Conflict Resolution

--- a/git-workflows/skills/sync-main/SKILL.md
+++ b/git-workflows/skills/sync-main/SKILL.md
@@ -26,7 +26,7 @@ or all open PR branches when using the `all` parameter.
 
 1. **Verify state**: `git branch --show-current`, `git status --porcelain`
    - STOP if on main or uncommitted changes
-2. **Find and sync main**: `cd ${GIT_HOME_PUBLIC}/<repo>/main && git fetch --all --prune --force && git pull`
+2. **Sync main**: `git fetch --all --prune --force && git pull` (in `main/`)
 3. **Check for updates**: `git fetch origin --force main`
 4. **Report**: Show commits behind with `git log --oneline HEAD..origin/main` (informational only)
 5. **Merge**: `git merge origin/main --no-edit`

--- a/git-workflows/skills/troubleshoot-worktree/SKILL.md
+++ b/git-workflows/skills/troubleshoot-worktree/SKILL.md
@@ -46,14 +46,14 @@ Means TWO things named `origin/main`:
 ### Main Worktree Not Found
 
 ```bash
-git worktree add ${GIT_HOME_PUBLIC}/<repo>/main main
+git worktree add main main
 ```
 
 ### Branch Worktree Not Found
 
 ```bash
 git fetch origin --force <branch>
-git worktree add ${GIT_HOME_PUBLIC}/<repo>/<branch> <branch>
+git worktree add ../<branch> <branch>
 ```
 
 ### Branch Not Found

--- a/github-workflows/skills/rebase-pr/SKILL.md
+++ b/github-workflows/skills/rebase-pr/SKILL.md
@@ -72,7 +72,6 @@ that skill.
 ## Step 2: Sync Main
 
 ```bash
-cd ${GIT_HOME_PUBLIC}/{repo}/main
 git fetch origin --force main
 git pull origin main
 ```
@@ -90,8 +89,8 @@ git branch {branch} origin/{branch}
 Create worktree and rebase:
 
 ```bash
-git worktree add ${GIT_HOME_PUBLIC}/{repo}/{worktree-path} {branch}
-cd ${GIT_HOME_PUBLIC}/{repo}/{worktree-path}
+git worktree add ../{worktree-path} {branch}   # from main/
+cd ../{worktree-path}
 git rebase origin/main
 git log --oneline origin/main..HEAD   # verify commits are ahead
 ```
@@ -117,7 +116,7 @@ git push --force-with-lease origin {branch}
 ## Step 5: Fast-Forward Merge to Main
 
 ```bash
-cd ${GIT_HOME_PUBLIC}/{repo}/main
+cd ../main
 git merge-base --is-ancestor origin/main {branch}  # verify FF is possible; exit 0 = yes
 git merge --ff-only {branch}
 ```
@@ -146,7 +145,7 @@ gh pr view <PR_NUMBER> --json state --jq '.state'   # expect: MERGED
 ## Step 7: Cleanup
 
 ```bash
-git worktree remove ${GIT_HOME_PUBLIC}/{repo}/{worktree-path}
+git worktree remove ../{worktree-path}   # from main/
 git branch -d {branch}              # use -D only after confirming state=MERGED
 git push origin --delete {branch}
 git worktree prune

--- a/github-workflows/skills/refresh-repo/SKILL.md
+++ b/github-workflows/skills/refresh-repo/SKILL.md
@@ -53,14 +53,14 @@ Replace `<OWNER>`, `<REPO>`, `<PR_NUMBER>` per the placeholder legend in that sk
 2. Fetch origin with stale remote branch pruning, but without tag updates:
    `git fetch origin --no-tags --prune --force`
 3. Determine the default branch from `origin/HEAD`, falling back to `main` or `master`.
-4. **Restore the default-branch worktree to the default branch.** Per the workspace
-   convention in `${GIT_HOME}/CLAUDE.md`, `<repo>/main/` (or `<repo>/master/`) must always
-   be checked out to the default branch. After a feature PR merges, that worktree is
-   often left on the now-`[gone]` feature branch. Detect and fix:
-   - Resolve the default worktree path using the workspace convention:
-     `${GIT_HOME_PUBLIC}/<repo>/<default>/`. Do not rely on basename matching from
-     `git worktree list` — a feature branch named `feature/<default>` would also
-     produce a path basename of `<default>`.
+4. **Restore the default-branch worktree to the default branch.** Per the
+   workspace convention, `<repo>/main/` (or `<repo>/master/`) must always
+   be checked out to the default branch. After a feature PR merges, that
+   worktree is often left on the now-`[gone]` feature branch. Detect and fix:
+   - Resolve the default worktree path from `git worktree list --porcelain`,
+     matching on the `branch refs/heads/<default>` entry — do not rely on
+     basename matching of paths, since a feature branch named
+     `feature/<default>` would also produce a path basename of `<default>`.
    - If that path exists and `git -C <path> rev-parse --abbrev-ref HEAD` does not equal
      `<default>` (this is safer than `symbolic-ref --short HEAD`, which errors on
      detached HEAD during a rebase or commit-checkout):
@@ -151,9 +151,9 @@ safety.
 
 ### `--sweep [<repo-glob>]`
 
-Multi-repo cleanup of abandoned local branches. For each repo matching the
-glob (default `${GIT_HOME_PUBLIC}/*/main/`), for every local branch where
-`git log origin/main..HEAD` is non-empty:
+Multi-repo cleanup of abandoned local branches. For every main worktree
+in your workspace (caller can pass a custom glob if their layout differs),
+for every local branch where `git log origin/main..HEAD` is non-empty:
 
 1. **Content-equivalence check**: compute merge base, diff each touched file
    against current `origin/main`. If every touched file is content-equivalent

--- a/infra-orchestration/skills/orchestrate-infra/SKILL.md
+++ b/infra-orchestration/skills/orchestrate-infra/SKILL.md
@@ -39,7 +39,7 @@ Full pipeline validation: validate, plan, export inventory, syntax-check, check,
 
 ## Execution Pattern
 
-1. **Resolve repo paths**: All repos at `${GIT_HOME_PUBLIC}/<repo-name>/main/`
+1. **Resolve repo paths**: locate each target repo locally
 2. **Dispatch Terraform phase**: Launch subagent for terraform-proxmox operations
 3. **Await completion**: Terraform must complete before Ansible phases
 4. **Dispatch Ansible phases**: Launch parallel subagents for independent Ansible repos (invoke `superpowers:dispatching-parallel-agents`)

--- a/infra-orchestration/skills/sync-inventory/SKILL.md
+++ b/infra-orchestration/skills/sync-inventory/SKILL.md
@@ -17,8 +17,9 @@ Export Terraform outputs as Ansible inventory and distribute the generated inven
 
 ### 1. Export Terraform Inventory
 
+In `terraform-proxmox`:
+
 ```bash
-cd ${GIT_HOME_PUBLIC}/terraform-proxmox/main
 doppler run -- terragrunt output -json ansible_inventory
 ```
 
@@ -28,11 +29,11 @@ Convert Terraform JSON output to Ansible inventory YAML format with host groups,
 
 ### 3. Distribute to Ansible Repos
 
-Copy the generated inventory to:
+Copy the generated `inventory/` into each:
 
-- `${GIT_HOME_PUBLIC}/ansible-proxmox/main/inventory/`
-- `${GIT_HOME_PUBLIC}/ansible-proxmox-apps/main/inventory/`
-- `${GIT_HOME_PUBLIC}/ansible-splunk/main/inventory/`
+- `ansible-proxmox`
+- `ansible-proxmox-apps`
+- `ansible-splunk`
 
 ### 4. Validate
 
@@ -42,7 +43,7 @@ Run `ansible-inventory --list -i inventory/hosts.yml` in each target repo to con
 
 - Terraform state must exist (run `terragrunt apply` first)
 - Doppler configured with `iac-conf-mgmt` project
-- All target Ansible repos must be checked out at `${GIT_HOME_PUBLIC}/<repo>/main/`
+- Each target Ansible repo is checked out locally
 
 ## Error Handling
 

--- a/infra-orchestration/skills/test-e2e/SKILL.md
+++ b/infra-orchestration/skills/test-e2e/SKILL.md
@@ -12,15 +12,17 @@ Validates syntax, plans changes, exports inventory, and dry-runs Ansible playboo
 
 ### Stage 1: Terraform Validate
 
+In `terraform-proxmox`:
+
 ```bash
-cd ${GIT_HOME_PUBLIC}/terraform-proxmox/main
 doppler run -- terragrunt validate
 ```
 
 ### Stage 2: Terraform Plan
 
+In `terraform-proxmox`:
+
 ```bash
-cd ${GIT_HOME_PUBLIC}/terraform-proxmox/main
 doppler run -- terragrunt plan
 ```
 


### PR DESCRIPTION
## Summary

Follow-up to #330. That PR swapped hardcoded `~/git/...` references for `${GIT_HOME_PUBLIC}/<repo>/...`. Reviewer pushback: skill docs and convention rules shouldn't bake any local workspace path into prose at all — describe what to do, not where files live.

## What changed (10 files)

- **`.claude/rules/worktree-conventions.md`**: convention table shows relative paths (`<repo>/main/`, `<repo>/{branch-name}/`). Operational sync line drops `cd`, frames as "from the main worktree".
- **`git-standards/skills/git-workflow-standards/SKILL.md`**: layout diagram + table use relative paths. Create/Remove commands use `../` from the main worktree.
- **`git-workflows/skills/sync-main`**: "find and sync main" describes the worktree role; drops `cd`.
- **`git-workflows/skills/troubleshoot-worktree`**: `git worktree add ../<branch>` (relative).
- **`github-workflows/skills/rebase-pr`**: "from the main worktree" framing.
- **`github-workflows/skills/refresh-repo`**: drop the `${GIT_HOME}/CLAUDE.md` citation; drop the `${GIT_HOME_PUBLIC}/<repo>/<default>/` path-resolution rule in favor of `git worktree list --porcelain` matching on `branch refs/heads/<default>`; `--sweep` glob description loosened.
- **`infra-orchestration/orchestrate-infra`**: "locate each target repo's main worktree" instead of a path glob.
- **`infra-orchestration/sync-inventory`**: "from the X main worktree" framing; repo list shows names only.
- **`infra-orchestration/test-e2e`**: same.
- **`codeql-resolver/README.md`**: examples annotate the worktree, drop `cd`.

## Why this PR exists separately from #330

The user merged #330 quickly after open; the further-cleanup amend (this PR's content) didn't have time to apply pre-merge. Splitting into a follow-up keeps history clean rather than force-pushing already-merged content.

## Related

- #330 — the initial path-variable sweep this builds on
- Sibling follow-up PR in `JacobPEvans/ai-assistant-instructions#658` applying the same lens
- The `${GIT_HOME}` / `${GIT_HOME_PUBLIC}` nix-home sessionVariables stay — this PR just stops referencing them in docs where they're not load-bearing

Assisted-by: Claude <noreply@anthropic.com>