### PR TITLE
fix(content-guards): cap markdown validator output to prevent context bloat

### DIFF
--- a/content-guards/scripts/validate-markdown.sh
+++ b/content-guards/scripts/validate-markdown.sh
@@ -154,14 +154,18 @@ EOF
   } 2>&1 ); then
     errors+=("markdownlint-cli2 failed:")
     # Cap validator output so a noisy run can't flood Claude's context window.
+    # Single awk pass counts, caps, and formats the overflow footer.
     max_lines=20
-    total_lines=$(awk 'END{print NR}' <<<"$markdownlint_output")
-    if (( total_lines > max_lines )); then
-      capped=$(awk -v max="$max_lines" 'NR<=max' <<<"$markdownlint_output")
-      capped+=$'\n…and '"$((total_lines - max_lines))"' more line(s) (capped at '"$max_lines"'; rerun markdownlint-cli2 manually for the full report)'
+    if [[ -n "$markdownlint_output" ]]; then
+      capped=$(awk -v max="$max_lines" '
+        NR <= max { print }
+        END {
+          if (NR > max) {
+            print "…and " (NR - max) " more line(s) (capped at " max "; rerun markdownlint-cli2 manually for the full report)"
+          }
+        }
+      ' <<<"$markdownlint_output")
       errors+=("$capped")
-    else
-      errors+=("$markdownlint_output")
     fi
   fi
 fi

--- a/content-guards/scripts/validate-markdown.sh
+++ b/content-guards/scripts/validate-markdown.sh
@@ -153,7 +153,16 @@ EOF
     fi
   } 2>&1 ); then
     errors+=("markdownlint-cli2 failed:")
-    errors+=("$markdownlint_output")
+    # Cap validator output so a noisy run can't flood Claude's context window.
+    max_lines=20
+    total_lines=$(awk 'END{print NR}' <<<"$markdownlint_output")
+    if (( total_lines > max_lines )); then
+      capped=$(awk -v max="$max_lines" 'NR<=max' <<<"$markdownlint_output")
+      capped+=$'\n…and '"$((total_lines - max_lines))"' more line(s) (capped at '"$max_lines"'; rerun markdownlint-cli2 manually for the full report)'
+      errors+=("$capped")
+    else
+      errors+=("$markdownlint_output")
+    fi
   fi
 fi
 


### PR DESCRIPTION
## Summary

- Cap `validate-markdown.sh` PostToolUse hook output to first 20 lines + overflow summary.
- Prevents unbounded `markdownlint-cli2` violation dumps from filling Claude's context window.

## Why

The hook currently captures full `markdownlint-cli2` stderr/stdout into the `blockingError` string returned to Claude with no bound. In a recent session scaffolding a new terraform module, a single noisy file (README with long mermaid blocks under default MD013 line-length) emitted **~500KB of lint output per Write**. A 15-file scaffold pushed the session past the 1,000,000-token limit — final transcript landed at **2,082,547 tokens, 85% markdownlint-attributed**. `/compact` couldn't recover; the session bricked.

## Change

Lines 147–157 of `content-guards/scripts/validate-markdown.sh`:

- Before: `errors+=("$markdownlint_output")` — unbounded.
- After: cap to first 20 violation lines via `awk`, append `"...and N more line(s)"` overflow summary if total exceeds the cap. Worst-case payload ~2KB vs ~500KB before.

Hook still `exit 2`s on failure — blocking behavior unchanged. `awk` chosen over `head`/`wc` to avoid SIGPIPE concerns under `set -euo pipefail`.

## Test plan

- [x] `bash -n` passes on patched script.
- [x] Smoke test: 120-line noisy file (intentional MD013 violations) → exit 2, 26 lines / 1893 bytes total, footer reads `…and 105 more line(s) (capped at 20; rerun markdownlint-cli2 manually for the full report)`.
- [ ] `release-please` drafts content-guards 1.7.0 → 1.7.1 on merge.
- [ ] After plugin re-cache, real Write to a noisy `.md` produces bounded hook output in a live Claude Code session.

Sibling `validate-readme.py` was investigated and confirmed already-bounded (3 fires × ~1.2KB in the same incident); no change needed there.

🤖 Generated with [Claude Code](https://claude.com/claude-code)