### PR TITLE
feat(content-guards): add secret-guard PreToolUse hook

### DIFF
--- a/content-guards/.claude-plugin/plugin.json
+++ b/content-guards/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "content-guards",
-  "version": "1.7.0",
-  "description": "Combined content validation and guard plugin: token-validator, markdown-validator, readme-validator, webfetch-guard, and issue/PR rate limiter",
+  "version": "1.8.0",
+  "description": "Combined content validation and guard plugin: token-validator, markdown-validator, readme-validator, webfetch-guard, secret-guard, and issue/PR rate limiter",
   "author": {
     "name": "JacobPEvans"
   },
@@ -14,6 +14,8 @@
     "markdown",
     "readme",
     "webfetch",
+    "secret-guard",
+    "secrets",
     "issue-management",
     "rate-limiting",
     "code-quality"

--- a/content-guards/ARCHITECTURE.md
+++ b/content-guards/ARCHITECTURE.md
@@ -1,6 +1,6 @@
 # content-guards — Architecture
 
-Pre-flight and post-flight content validation through 6 hooks across PreToolUse and
+Pre-flight and post-flight content validation through 7 hooks across PreToolUse and
 PostToolUse events. These run automatically on every qualifying tool call.
 
 ## Validation Pipeline
@@ -15,6 +15,7 @@ flowchart TD
         direction TB
         TV["validate-token-limits.py\nmatcher: Write | Edit"]:::pre
         WG["webfetch-guard.py\nmatcher: WebFetch | WebSearch"]:::pre
+        SG["secret-guard.py\nmatcher: Write | Edit | MultiEdit | NotebookEdit"]:::pre
         IL["enforce-issue-limits.py\nmatcher: Bash"]:::pre
         BL["enforce-branch-limits.py\nmatcher: Bash"]:::pre
     end
@@ -28,7 +29,7 @@ flowchart TD
     end
 
     PRE -->|"pass (exit 0)"| TOOL
-    PRE -->|"block (exit 2)"| BLOCKED["Operation denied"]
+    PRE -->|"block (exit 2, or deny JSON)"| BLOCKED["Operation denied"]
     TOOL --> POST
     POST -->|"warn"| WARN["Lint warnings injected\ninto assistant context"]
 
@@ -42,6 +43,7 @@ flowchart TD
 |------|-------|---------|-------------|
 | token-validator | PreToolUse | Write, Edit | Blocks files exceeding token limits |
 | webfetch-guard | PreToolUse | WebFetch, WebSearch | Blocks outdated year references in queries |
+| secret-guard | PreToolUse | Write, Edit, MultiEdit, NotebookEdit | Blocks hardcoded sensitive homelab values (keychain denylist + RFC1918 IP shapes); fail-open |
 | issue-limiter | PreToolUse | Bash | Rate limits `gh issue create` and `gh pr create` |
 | branch-limiter | PreToolUse | Bash | Limits concurrent open branches |
 | markdown-validator | PostToolUse | Write, Edit | Runs markdownlint on written files |

--- a/content-guards/README.md
+++ b/content-guards/README.md
@@ -9,6 +9,7 @@ See [ARCHITECTURE.md](ARCHITECTURE.md) for integration diagrams.
 - **markdown-validator**: Validates markdown with markdownlint
 - **token-validator**: Enforces configurable file token limits
 - **webfetch-guard**: Blocks outdated year references in web queries
+- **secret-guard**: Blocks hardcoded sensitive homelab values (real IPs/domain) in writes
 - **readme-validator**: Checks README files for required sections and badge health
 - **issue-limiter**: Prevents GitHub issue backlog overflow with 24h rate limiting
 
@@ -18,6 +19,7 @@ No manual invocation required. All hooks activate automatically:
 
 - **token-validator** — blocks files exceeding token limits (PreToolUse: Write, Edit)
 - **webfetch-guard** — blocks outdated year references in web queries (PreToolUse: WebFetch, WebSearch)
+- **secret-guard** — blocks hardcoded sensitive homelab values (PreToolUse: Write, Edit, MultiEdit, NotebookEdit)
 - **issue-limiter** — rate limits `gh issue create` and `gh pr create` (PreToolUse: Bash)
 - **branch-limiter** — limits concurrent open branches (PreToolUse: Bash)
 - **markdown-validator** — runs markdownlint after writes (PostToolUse: Write, Edit)
@@ -29,12 +31,45 @@ No manual invocation required. All hooks activate automatically:
 claude plugins add jacobpevans-cc-plugins/content-guards
 ```
 
+## secret-guard
+
+Blocks hardcoded sensitive homelab values from being written into a repo. Fires
+on every `Write`, `Edit`, `MultiEdit`, and `NotebookEdit`, inspecting the
+content field (`content`, `new_string`, `edits[].new_string`, or `new_source`).
+Two detection prongs:
+
+- **Literal** — a private, newline-separated POSIX-ERE denylist
+  (`SENSITIVE_DENYLIST`) loaded from the macOS auto-readable keychain via
+  `security find-generic-password -s SENSITIVE_DENYLIST -w`. Holds the exact
+  real domain, node names, pool names, and account ID. Never committed; the hook
+  only references it by name.
+- **Structural (value-free)** — RFC1918 internal IP literals (`10.`,
+  `192.168.`, `172.16-31.`). Fake test values (RFC2544 `198.18`/`198.19`,
+  `example.invalid`) are allowlisted so fixtures and docs never trip the guard.
+  A real-domain shape is also supported but **off by default** (it fires on
+  every write; a broad TLD match would be hostile) — opt in per repo via
+  `SECRET_GUARD_DOMAIN_REGEX`. The real domain is otherwise caught by the
+  literal prong.
+
+On a match it returns a `deny` decision naming the matched **category** (never
+the value), instructing the agent to parameterize via Doppler/SOPS. The hook is
+**fail-open**: a missing/empty denylist, an unreadable keychain, or any internal
+error allows the write with a one-line stderr warning, so fresh clones and
+external contributors are never blocked. The structural prong still runs when
+the literal denylist is unavailable.
+
+Environment overrides (testing only):
+
+- `SENSITIVE_DENYLIST_KEYCHAIN_SERVICE` — read a different keychain service.
+- `SECRET_GUARD_DOMAIN_REGEX` — enable/override the structural domain shape.
+
 ## Dependencies
 
 - `jq` - JSON processing
 - `atc` - Token counting tool
 - `markdownlint-cli2` - Markdown linting
 - `gh` - GitHub CLI
+- `security` - macOS keychain access (secret-guard literal denylist; fail-open if absent)
 
 ## Testing
 
@@ -56,6 +91,7 @@ Test coverage includes:
 - Unbound variable regression prevention (PR #39, #40)
 - Issue/PR rate limiting and hard-limit blocking
 - README required section and installation code block validation
+- secret-guard structural IP-shape detection, RFC2544/example.invalid allowlisting, and fail-open behavior (fake values only)
 
 ## License
 

--- a/content-guards/hooks/hooks.json
+++ b/content-guards/hooks/hooks.json
@@ -22,6 +22,16 @@
         ]
       },
       {
+        "matcher": "Write|Edit|MultiEdit|NotebookEdit",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "${CLAUDE_PLUGIN_ROOT}/scripts/secret-guard.py",
+            "timeout": 30
+          }
+        ]
+      },
+      {
         "matcher": "Bash",
         "hooks": [
           {

--- a/content-guards/scripts/secret-guard.py
+++ b/content-guards/scripts/secret-guard.py
@@ -1,0 +1,242 @@
+#!/usr/bin/env python3
+"""
+secret-guard.py - PreToolUse hook to block hardcoded sensitive homelab values.
+
+Inspects the content being written by Write/Edit/MultiEdit/NotebookEdit and
+denies the operation if it matches either:
+
+  1. LITERAL prong - a private, newline-separated POSIX-ERE denylist
+     (`SENSITIVE_DENYLIST`) loaded from the macOS auto-readable keychain. This
+     list holds the EXACT real domain, Proxmox node names, ZFS pool names, AWS
+     account ID, etc. It is NEVER committed; agents only reference it by name.
+
+  2. STRUCTURAL prong - value-free shape checks for RFC1918 internal IP literals
+     (`10.`, `192.168.`, `172.16-31.`). Fake test values (RFC2544 `198.18`/
+     `198.19`, `example.invalid`) are allowlisted so fixtures and this repo's own
+     docs never trip the guard. A configurable real-domain shape is also
+     supported but OFF by default (see SECRET_GUARD_DOMAIN_REGEX) - it fires on
+     every write, so a broad TLD match would be hostile; the real domain is
+     caught precisely by the literal prong instead.
+
+Fail mode: fail-OPEN. Any internal error, a missing/empty denylist, or an
+unreadable keychain results in ALLOW plus a one-line stderr warning - a fresh
+clone or external contributor without the keychain entry is never blocked, and
+a Write is never crashed by this hook. The structural prong still runs even
+when the literal denylist is unavailable.
+
+Deny protocol (mirrors content-guards/webfetch-guard.py and
+git-guards/main-branch-guard.py): JSON on stdout with permissionDecision=deny,
+exit 0.
+
+Environment overrides (for testing only):
+  SENSITIVE_DENYLIST_KEYCHAIN_SERVICE - keychain service name to read instead
+    of the default `SENSITIVE_DENYLIST` (point tests at a fake TEST service).
+  SECRET_GUARD_DOMAIN_REGEX - override the structural real-domain regex.
+"""
+
+import json
+import os
+import re
+import subprocess
+import sys
+
+DEFAULT_KEYCHAIN_SERVICE = "SENSITIVE_DENYLIST"
+
+# Structural real-IP shapes (RFC1918). Value-free - matches the shape, not a
+# specific homelab subnet. Word-ish boundaries avoid matching inside longer
+# numbers (e.g. version strings, timestamps).
+_RFC1918_PATTERNS = [
+    r"(?<!\d)10\.\d{1,3}\.\d{1,3}\.\d{1,3}",
+    r"(?<!\d)192\.168\.\d{1,3}\.\d{1,3}",
+    r"(?<!\d)172\.(?:1[6-9]|2[0-9]|3[01])\.\d{1,3}\.\d{1,3}",
+]
+_RFC1918_RE = re.compile("|".join(_RFC1918_PATTERNS))
+
+# Fake test/documentation values that must always be allowed. These let the
+# repo's own fixtures and docs reference IP/domain shapes without tripping the
+# guard. RFC2544 benchmarking block 198.18.0.0/15 + RFC6761 example.invalid.
+_ALLOWLIST_RE = re.compile(
+    r"198\.1[89]\.\d{1,3}\.\d{1,3}"
+    r"|(?:[A-Za-z0-9-]+\.)*example\.invalid",
+    re.IGNORECASE,
+)
+
+# Structural real-domain shape. DISABLED by default (empty regex matches
+# nothing) because this hook fires on EVERY write across all repos: a broad
+# TLD match would deny ordinary content mentioning github.com, anthropic.com,
+# example.com, etc., making the guard hostile. The real homelab domain is
+# caught precisely by the LITERAL keychain prong instead. A repo that wants a
+# structural domain backstop sets SECRET_GUARD_DOMAIN_REGEX to its own shape
+# (example.invalid stays allowlisted). Empty string => prong off.
+_DEFAULT_DOMAIN_REGEX = ""
+
+
+def deny(category: str) -> None:
+    """Emit the ecosystem deny protocol and exit 0.
+
+    The matched VALUE is never echoed - only the category - so a secret that
+    triggered the guard is not re-surfaced in the decision reason.
+    """
+    reason = (
+        "secret-guard: content matches a sensitive homelab value "
+        f"(category: {category}) - parameterize via Doppler/SOPS instead of "
+        "hardcoding (see SENSITIVE_DENYLIST). Reference the value from runtime "
+        "config or an encrypted file; do not write the literal into a public repo."
+    )
+    print(json.dumps({
+        "hookSpecificOutput": {
+            "hookEventName": "PreToolUse",
+            "permissionDecision": "deny",
+            "permissionDecisionReason": reason,
+        }
+    }))
+    sys.exit(0)
+
+
+def load_denylist() -> list[re.Pattern]:
+    """Load and compile the literal denylist from the keychain.
+
+    Returns an empty list (fail-open) on any failure: keychain miss, empty
+    value, unreadable entry, or a malformed regex line. Comment (`#`) and blank
+    lines are ignored. Each non-comment line is a POSIX-ERE pattern.
+    """
+    service = os.environ.get(
+        "SENSITIVE_DENYLIST_KEYCHAIN_SERVICE", DEFAULT_KEYCHAIN_SERVICE
+    )
+    try:
+        result = subprocess.run(
+            ["security", "find-generic-password", "-s", service, "-w"],
+            capture_output=True,
+            text=True,
+            timeout=10,
+        )
+    except (OSError, subprocess.SubprocessError) as e:
+        print(
+            f"Warning: secret-guard could not read keychain denylist ({e}); "
+            "literal prong skipped (fail-open).",
+            file=sys.stderr,
+        )
+        return []
+
+    if result.returncode != 0 or not result.stdout.strip():
+        print(
+            "Warning: secret-guard denylist unavailable or empty; literal prong "
+            "skipped (fail-open).",
+            file=sys.stderr,
+        )
+        return []
+
+    patterns: list[re.Pattern] = []
+    for raw in result.stdout.splitlines():
+        line = raw.strip()
+        if not line or line.startswith("#"):
+            continue
+        try:
+            patterns.append(re.compile(line))
+        except re.error:
+            print(
+                "Warning: secret-guard skipped an invalid denylist pattern.",
+                file=sys.stderr,
+            )
+            continue
+    return patterns
+
+
+def _strip_allowlisted(text: str) -> str:
+    """Remove fake test/doc values so they cannot trigger structural matches."""
+    return _ALLOWLIST_RE.sub("", text)
+
+
+def domain_regex() -> re.Pattern | None:
+    """Compile the structural domain regex, or None when the prong is off.
+
+    An empty pattern means "disabled" - returning None (rather than a compiled
+    empty regex, which would spuriously match every string at position 0).
+    """
+    pattern = os.environ.get("SECRET_GUARD_DOMAIN_REGEX", _DEFAULT_DOMAIN_REGEX)
+    if not pattern:
+        return None
+    try:
+        return re.compile(pattern, re.IGNORECASE)
+    except re.error:
+        return None
+
+
+def check_content(content: str, denylist: list[re.Pattern]) -> str | None:
+    """Return a category name if content matches a denied pattern, else None."""
+    if not content:
+        return None
+
+    # Literal prong runs against the RAW content (the real denylist values are
+    # never the fake allowlisted ones, so no stripping needed here).
+    for pattern in denylist:
+        if pattern.search(content):
+            return "literal-denylist"
+
+    # Structural prong runs against allowlist-stripped content so fake test
+    # values do not produce false positives.
+    scrubbed = _strip_allowlisted(content)
+    if _RFC1918_RE.search(scrubbed):
+        return "structural-rfc1918-ip"
+    domain_re = domain_regex()
+    if domain_re is not None and domain_re.search(scrubbed):
+        return "structural-real-domain"
+
+    return None
+
+
+def extract_content(tool_name: str, tool_input: dict) -> str:
+    """Concatenate every content-bearing field for the given tool."""
+    parts: list[str] = []
+
+    if tool_name == "Write":
+        parts.append(tool_input.get("content", ""))
+    elif tool_name == "Edit":
+        parts.append(tool_input.get("new_string", ""))
+    elif tool_name == "MultiEdit":
+        for edit in tool_input.get("edits", []):
+            if isinstance(edit, dict):
+                parts.append(edit.get("new_string", ""))
+    elif tool_name == "NotebookEdit":
+        # NotebookEdit writes a single cell's source.
+        parts.append(tool_input.get("new_source", ""))
+
+    return "\n".join(p for p in parts if isinstance(p, str) and p)
+
+
+def main() -> None:
+    try:
+        hook_input = json.load(sys.stdin)
+    except (json.JSONDecodeError, ValueError):
+        sys.exit(0)  # Invalid input - fail-open
+
+    try:
+        tool_name = hook_input.get("tool_name", "")
+        if tool_name not in ("Write", "Edit", "MultiEdit", "NotebookEdit"):
+            sys.exit(0)
+
+        tool_input = hook_input.get("tool_input", {})
+        if not isinstance(tool_input, dict):
+            sys.exit(0)
+
+        content = extract_content(tool_name, tool_input)
+        if not content:
+            sys.exit(0)
+
+        denylist = load_denylist()
+        category = check_content(content, denylist)
+        if category:
+            deny(category)
+    except Exception as e:  # noqa: BLE001 - fail-open is intentional and total
+        print(
+            f"Warning: secret-guard internal error ({e}); allowing write "
+            "(fail-open).",
+            file=sys.stderr,
+        )
+        sys.exit(0)
+
+    sys.exit(0)  # Allow
+
+
+if __name__ == "__main__":
+    main()

--- a/content-guards/scripts/test_secret_guard.py
+++ b/content-guards/scripts/test_secret_guard.py
@@ -1,0 +1,222 @@
+#!/usr/bin/env python3
+"""Tests for secret-guard.py hook.
+
+All sensitive inputs use FAKE values only: RFC2544 198.18/198.19 (allowed),
+RFC1918 198 -> we use 10./192.168./172.16-31. SHAPES with octets that are NOT
+any real homelab subnet, and example.invalid (allowed). No real value appears.
+
+Verifies:
+  - Structural RFC1918 IP shapes are denied.
+  - Real-domain shapes are denied; example.invalid is allowed.
+  - Fake RFC2544 198.18/198.19 IPs are allowed.
+  - Clean content is allowed (silent).
+  - Missing/empty keychain denylist fails OPEN (structural prong still runs).
+  - A seeded TEST keychain literal denylist denies a planted fake token.
+  - Edit/MultiEdit/NotebookEdit content fields are inspected.
+  - Non-matching tools are silently allowed.
+
+Run with: python3 content-guards/scripts/test_secret_guard.py
+"""
+
+import json
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+SCRIPT = Path(__file__).parent / "secret-guard.py"
+
+# A guaranteed-absent keychain service so the literal prong is unavailable by
+# default and the structural-only tests exercise the fail-open path.
+ABSENT_SERVICE = "SENSITIVE_DENYLIST_NONEXISTENT_TEST_SERVICE_ZZZ"
+
+
+def run(tool_input: dict, tool_name: str = "Write", env_extra=None) -> tuple[int, dict]:
+    inp = json.dumps({"tool_name": tool_name, "tool_input": tool_input})
+    env = dict(os.environ)
+    # Default: point the literal prong at an absent service (fail-open) unless a
+    # test overrides it.
+    env.setdefault("SENSITIVE_DENYLIST_KEYCHAIN_SERVICE", ABSENT_SERVICE)
+    if env_extra:
+        env.update(env_extra)
+    result = subprocess.run(
+        ["python3", str(SCRIPT)],
+        input=inp,
+        capture_output=True,
+        text=True,
+        env=env,
+    )
+    output = json.loads(result.stdout.strip()) if result.stdout.strip() else {}
+    return result.returncode, output
+
+
+def decision(output: dict) -> str:
+    if not output:
+        return "silent_allow"
+    return output["hookSpecificOutput"]["permissionDecision"]
+
+
+def check(label: str, expected: str, tool_input: dict, tool_name="Write", env_extra=None) -> bool:
+    _, output = run(tool_input, tool_name, env_extra)
+    actual = decision(output)
+    ok = actual == expected
+    print(f"{'PASS' if ok else 'FAIL'} [{label}]: decision={actual}")
+    if not ok:
+        print(f"  Expected: {expected}, Got: {actual}")
+        if output:
+            # Confirm the matched VALUE is never echoed back.
+            print(f"  reason={output['hookSpecificOutput']['permissionDecisionReason']}")
+    return ok
+
+
+all_pass = True
+
+# --- Structural prong: RFC1918 IP shapes are denied -------------------------
+all_pass &= check(
+    "rfc1918 10.x denied",
+    "deny",
+    {"file_path": "x.tf", "content": 'ip = "10.20.30.40"'},
+)
+all_pass &= check(
+    "rfc1918 192.168.x denied",
+    "deny",
+    {"file_path": "x.tf", "content": 'gateway = "192.168.5.1"'},
+)
+all_pass &= check(
+    "rfc1918 172.16-31.x denied",
+    "deny",
+    {"file_path": "x.tf", "content": 'host = "172.20.1.1"'},
+)
+
+# --- Allowlist: fake RFC2544 198.18/198.19 IPs are allowed ------------------
+all_pass &= check(
+    "rfc2544 198.18 allowed",
+    "silent_allow",
+    {"file_path": "fixture.tf", "content": 'ip = "198.18.0.10"'},
+)
+all_pass &= check(
+    "rfc2544 198.19 allowed",
+    "silent_allow",
+    {"file_path": "fixture.tf", "content": 'ip = "198.19.5.5"'},
+)
+
+# --- Structural domain prong is OFF by default (no false positives) ---------
+all_pass &= check(
+    "domain prong off by default allows github.com",
+    "silent_allow",
+    {"file_path": "x.md", "content": "see https://github.com/foo/bar for details"},
+)
+
+# --- Structural domain prong fires only when opted in via env var -----------
+_DOMAIN_ON = {"SECRET_GUARD_DOMAIN_REGEX": r"\b[a-z0-9-]+\.(?:com|net|org)\b"}
+all_pass &= check(
+    "real domain shape denied when prong enabled",
+    "deny",
+    {"file_path": "x.md", "content": "see myhost.example.com for details"},
+    env_extra=_DOMAIN_ON,
+)
+all_pass &= check(
+    "example.invalid allowed even when domain prong enabled",
+    "silent_allow",
+    {"file_path": "x.md", "content": "see node.example.invalid for details"},
+    env_extra=_DOMAIN_ON,
+)
+
+# --- Clean content is allowed -----------------------------------------------
+all_pass &= check(
+    "clean content allowed",
+    "silent_allow",
+    {"file_path": "x.py", "content": "def add(a, b):\n    return a + b\n"},
+)
+
+# --- Edit / MultiEdit / NotebookEdit fields are inspected -------------------
+all_pass &= check(
+    "Edit new_string denied",
+    "deny",
+    {"file_path": "x.tf", "old_string": "a", "new_string": 'ip = "10.1.2.3"'},
+    tool_name="Edit",
+)
+all_pass &= check(
+    "MultiEdit edits[].new_string denied",
+    "deny",
+    {"file_path": "x.tf", "edits": [{"old_string": "a", "new_string": 'ip = "192.168.9.9"'}]},
+    tool_name="MultiEdit",
+)
+all_pass &= check(
+    "NotebookEdit new_source denied",
+    "deny",
+    {"notebook_path": "x.ipynb", "new_source": 'host = "172.18.0.1"'},
+    tool_name="NotebookEdit",
+)
+all_pass &= check(
+    "Edit clean new_string allowed",
+    "silent_allow",
+    {"file_path": "x.tf", "old_string": "a", "new_string": "value = 42"},
+    tool_name="Edit",
+)
+
+# --- Non-matching tool is silently allowed ----------------------------------
+all_pass &= check(
+    "non-matching tool allowed",
+    "silent_allow",
+    {"command": 'echo "10.1.2.3"'},
+    tool_name="Bash",
+)
+
+# --- Fail-OPEN: absent keychain still allows clean + denies structural ------
+# (the absent-service default already exercises this for every case above)
+all_pass &= check(
+    "fail-open absent keychain allows clean",
+    "silent_allow",
+    {"file_path": "x.py", "content": "print('hello world')"},
+)
+
+# --- Literal prong: seeded TEST keychain service denies a planted fake ------
+# Seed a TEMPORARY fake entry in the auto-readable login keychain, point the
+# hook at it, then delete it. If the keychain write prompts (non-interactive
+# failure), skip this prong gracefully rather than block the suite.
+TEST_SERVICE = "SENSITIVE_DENYLIST_TEST_SECRETGUARD"
+# Fake denylist: a regex matching a clearly-fake planted token. NOT a real value.
+FAKE_DENYLIST = "examplenode1\nexamplepool\nFAKE-PLANTED-TOKEN-[0-9]+\n"
+user = os.environ.get("USER", "")
+seeded = False
+try:
+    add = subprocess.run(
+        ["security", "add-generic-password", "-a", user, "-s", TEST_SERVICE,
+         "-w", FAKE_DENYLIST, "-U"],
+        capture_output=True, text=True, timeout=10,
+    )
+    seeded = add.returncode == 0
+except (OSError, subprocess.SubprocessError):
+    seeded = False
+
+if seeded:
+    all_pass &= check(
+        "literal denylist denies planted fake token",
+        "deny",
+        {"file_path": "x.tf", "content": "token = FAKE-PLANTED-TOKEN-42"},
+        env_extra={"SENSITIVE_DENYLIST_KEYCHAIN_SERVICE": TEST_SERVICE},
+    )
+    all_pass &= check(
+        "literal denylist denies fake node name",
+        "deny",
+        {"file_path": "x.tf", "content": "node = examplenode1"},
+        env_extra={"SENSITIVE_DENYLIST_KEYCHAIN_SERVICE": TEST_SERVICE},
+    )
+    all_pass &= check(
+        "literal denylist allows clean content",
+        "silent_allow",
+        {"file_path": "x.py", "content": "x = 1"},
+        env_extra={"SENSITIVE_DENYLIST_KEYCHAIN_SERVICE": TEST_SERVICE},
+    )
+    # Clean up the temporary entry.
+    subprocess.run(
+        ["security", "delete-generic-password", "-a", user, "-s", TEST_SERVICE],
+        capture_output=True, text=True, timeout=10,
+    )
+else:
+    print("SKIP [literal denylist]: keychain seeding unavailable (non-interactive)")
+
+print()
+print("ALL TESTS PASSED" if all_pass else "SOME TESTS FAILED")
+sys.exit(0 if all_pass else 1)

--- a/tests/content-guards/secret-guard/secret-guard.bats
+++ b/tests/content-guards/secret-guard/secret-guard.bats
@@ -1,0 +1,150 @@
+#!/usr/bin/env bats
+# Test suite for content-guards/scripts/secret-guard.py
+#
+# All sensitive inputs are FAKE: RFC1918 IP SHAPES with non-homelab octets,
+# RFC2544 198.18/198.19 (allowlisted), and example.invalid (allowlisted).
+# No real homelab value appears anywhere in this file.
+#
+# The literal-denylist prong is exercised by pointing the hook at an ABSENT
+# keychain service (fail-open) for structural tests. A seeded-keychain literal
+# test is covered by the companion test_secret_guard.py, which can clean up its
+# own temporary entry; bats keeps to the value-free structural + fail-open path.
+#
+# Run with: bats tests/content-guards/secret-guard/secret-guard.bats
+
+setup() {
+  REPO_ROOT="$(cd "$(dirname "$BATS_TEST_FILENAME")/../../.." && pwd)"
+  SCRIPT="$REPO_ROOT/content-guards/scripts/secret-guard.py"
+
+  if [[ ! -f "$SCRIPT" ]]; then
+    echo "ERROR: Script not found at $SCRIPT" >&2
+    return 1
+  fi
+
+  # Point the literal prong at a guaranteed-absent keychain service so the
+  # structural prong is what's under test and the literal prong fails open.
+  export SENSITIVE_DENYLIST_KEYCHAIN_SERVICE="SENSITIVE_DENYLIST_NONEXISTENT_TEST_SERVICE_ZZZ"
+}
+
+run_hook() {
+  run python3 "$SCRIPT" <<< "$1"
+}
+
+# --- Non-matching tool is silently allowed ----------------------------------
+
+@test "TC1: Bash tool is allowed silently" {
+  run_hook '{"tool_name":"Bash","tool_input":{"command":"echo 10.1.2.3"}}'
+  [ "$status" -eq 0 ]
+  [ -z "$output" ]
+}
+
+# --- Invalid JSON fails open (allow, exit 0) --------------------------------
+
+@test "TC2: invalid JSON input fails open (exit 0, no deny)" {
+  run python3 "$SCRIPT" <<< "not valid json"
+  [ "$status" -eq 0 ]
+  [[ ! "$output" =~ "deny" ]]
+}
+
+# --- Structural RFC1918 IP shapes are denied --------------------------------
+
+@test "TC3: Write with 10.x IP shape is denied" {
+  run_hook '{"tool_name":"Write","tool_input":{"file_path":"x.tf","content":"ip = \"10.20.30.40\""}}'
+  [ "$status" -eq 0 ]
+  [[ "$output" =~ "deny" ]]
+  [[ "$output" =~ "rfc1918" ]]
+}
+
+@test "TC4: Write with 192.168.x IP shape is denied" {
+  run_hook '{"tool_name":"Write","tool_input":{"file_path":"x.tf","content":"gw = \"192.168.5.1\""}}'
+  [ "$status" -eq 0 ]
+  [[ "$output" =~ "deny" ]]
+}
+
+@test "TC5: Write with 172.16-31.x IP shape is denied" {
+  run_hook '{"tool_name":"Write","tool_input":{"file_path":"x.tf","content":"h = \"172.20.1.1\""}}'
+  [ "$status" -eq 0 ]
+  [[ "$output" =~ "deny" ]]
+}
+
+# --- Allowlist: fake RFC2544 198.18/198.19 IPs are allowed ------------------
+
+@test "TC6: Write with RFC2544 198.18 IP is allowed silently" {
+  run_hook '{"tool_name":"Write","tool_input":{"file_path":"x.tf","content":"ip = \"198.18.0.10\""}}'
+  [ "$status" -eq 0 ]
+  [ -z "$output" ]
+}
+
+@test "TC7: Write with RFC2544 198.19 IP is allowed silently" {
+  run_hook '{"tool_name":"Write","tool_input":{"file_path":"x.tf","content":"ip = \"198.19.5.5\""}}'
+  [ "$status" -eq 0 ]
+  [ -z "$output" ]
+}
+
+# --- Structural domain prong is OFF by default (no false positives) ---------
+
+@test "TC8: Write mentioning github.com is allowed (domain prong off by default)" {
+  run_hook '{"tool_name":"Write","tool_input":{"file_path":"x.md","content":"see https://github.com/foo/bar here"}}'
+  [ "$status" -eq 0 ]
+  [ -z "$output" ]
+}
+
+# --- Structural domain prong fires only when opted in via env var -----------
+
+@test "TC8b: Write with real-domain shape is denied when prong enabled" {
+  SECRET_GUARD_DOMAIN_REGEX='\b[a-z0-9-]+\.(com|net|org)\b' \
+    run_hook '{"tool_name":"Write","tool_input":{"file_path":"x.md","content":"see myhost.example.com here"}}'
+  [ "$status" -eq 0 ]
+  [[ "$output" =~ "deny" ]]
+  [[ "$output" =~ "domain" ]]
+}
+
+@test "TC9: example.invalid is allowed even when domain prong enabled" {
+  SECRET_GUARD_DOMAIN_REGEX='\b[a-z0-9-]+\.(com|net|org)\b' \
+    run_hook '{"tool_name":"Write","tool_input":{"file_path":"x.md","content":"see node.example.invalid here"}}'
+  [ "$status" -eq 0 ]
+  [ -z "$output" ]
+}
+
+# --- Clean content is allowed -----------------------------------------------
+
+@test "TC10: Write with clean content is allowed silently" {
+  run_hook '{"tool_name":"Write","tool_input":{"file_path":"x.py","content":"def add(a, b):\n    return a + b"}}'
+  [ "$status" -eq 0 ]
+  [ -z "$output" ]
+}
+
+# --- Edit / MultiEdit / NotebookEdit content fields are inspected -----------
+
+@test "TC11: Edit new_string with IP shape is denied" {
+  run_hook '{"tool_name":"Edit","tool_input":{"file_path":"x.tf","old_string":"a","new_string":"ip = \"10.1.2.3\""}}'
+  [ "$status" -eq 0 ]
+  [[ "$output" =~ "deny" ]]
+}
+
+@test "TC12: MultiEdit edits[].new_string with IP shape is denied" {
+  run_hook '{"tool_name":"MultiEdit","tool_input":{"file_path":"x.tf","edits":[{"old_string":"a","new_string":"ip = \"192.168.9.9\""}]}}'
+  [ "$status" -eq 0 ]
+  [[ "$output" =~ "deny" ]]
+}
+
+@test "TC13: NotebookEdit new_source with IP shape is denied" {
+  run_hook '{"tool_name":"NotebookEdit","tool_input":{"notebook_path":"x.ipynb","new_source":"h = \"172.18.0.1\""}}'
+  [ "$status" -eq 0 ]
+  [[ "$output" =~ "deny" ]]
+}
+
+@test "TC14: Edit with clean new_string is allowed silently" {
+  run_hook '{"tool_name":"Edit","tool_input":{"file_path":"x.tf","old_string":"a","new_string":"value = 42"}}'
+  [ "$status" -eq 0 ]
+  [ -z "$output" ]
+}
+
+# --- Deny reason never echoes the matched value -----------------------------
+
+@test "TC15: deny reason names a category, not the matched IP value" {
+  run_hook '{"tool_name":"Write","tool_input":{"file_path":"x.tf","content":"ip = \"10.20.30.40\""}}'
+  [ "$status" -eq 0 ]
+  [[ "$output" =~ "deny" ]]
+  [[ ! "$output" =~ "10.20.30.40" ]]
+}


### PR DESCRIPTION
## Summary

Layer 1 of the multi-layer sensitive-value prevention system: a `secret-guard`
PreToolUse hook in the `content-guards` plugin that blocks hardcoded sensitive
homelab values from being written into a repo. It fires on
`Write|Edit|MultiEdit|NotebookEdit` and inspects the content field
(`content`, `new_string`, `edits[].new_string`, `new_source`).

## Detection prongs

- **Literal** — a private newline-separated POSIX-ERE denylist
  (`SENSITIVE_DENYLIST`) read from the macOS auto-readable keychain via
  `security find-generic-password -s SENSITIVE_DENYLIST -w`. Holds the exact
  real domain, node/pool names, and account ID. Never committed; referenced by
  name only.
- **Structural (value-free)** — RFC1918 internal IP literals
  (`10.`/`192.168.`/`172.16-31.`), allowlisting fake test values (RFC2544
  `198.18`/`198.19`, `example.invalid`). A real-domain shape is supported but
  **off by default** (the hook fires on every write, so a broad TLD match would
  block ordinary content mentioning `github.com` etc. and be hostile) — opt in
  per repo via `SECRET_GUARD_DOMAIN_REGEX`. The real domain is caught by the
  literal prong instead.

## Behavior

- **Deny protocol**: mirrors `webfetch-guard.py` / `main-branch-guard.py` — JSON
  `hookSpecificOutput`/`permissionDecision: deny` on stdout, exit 0. The reason
  names the matched **category**, never the matched value, so a secret is not
  re-surfaced.
- **Fail-open**: a missing/empty denylist, an unreadable keychain, or any
  internal error allows the write with a one-line stderr warning. Fresh clones
  and external contributors without the keychain entry are never blocked; the
  structural prong still runs when the literal denylist is unavailable.

## Files

- `content-guards/scripts/secret-guard.py` (new, executable)
- `content-guards/scripts/test_secret_guard.py` (new, executable) — self-contained
- `tests/content-guards/secret-guard/secret-guard.bats` (new) — CI bats suite
- `content-guards/hooks/hooks.json` — register the PreToolUse matcher
- `content-guards/README.md`, `content-guards/ARCHITECTURE.md` — docs
- `content-guards/.claude-plugin/plugin.json` — version 1.7.0 -> 1.8.0, keywords

## Testing (FAKE values only)

Tests use only fake values: RFC1918 IP **shapes** with non-homelab octets,
RFC2544 `198.18`/`198.19` (allowlisted), `example.invalid` (allowlisted). CI
runs both the bats suite and the python test. Coverage: structural IP-shape
deny, RFC2544/example.invalid allowlisting, clean-content allow, Edit/MultiEdit/
NotebookEdit field extraction, domain prong off-by-default + opt-in, fail-open
on absent keychain, deny-reason omits the matched value, and (on macOS only) a
seeded TEST-keychain literal-denylist deny that cleans up its own entry.

## Docs mirroring (for the lead)

Per repo-boundaries, mirror into `JacobPEvans/docs`
`docs/ai-development/claude-code-plugins.mdx`: content-guards now ships a
**secret-guard** PreToolUse hook (matcher `Write|Edit|MultiEdit|NotebookEdit`)
— keychain `SENSITIVE_DENYLIST` literal prong + value-free RFC1918 structural
prong, fail-open, with `SECRET_GUARD_DOMAIN_REGEX` opt-in. Plugin version 1.8.0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)