### PR TITLE
feat: migrate situational rules to on-demand skills, de-drift standards

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ Combined git security and workflow protection via PreToolUse hooks.
 Git main branch sync, repository refresh, and PR merge workflows.
 
 - **Type**: Command/Skill-based plugin
-- **Skills**: `/sync-main`, `/refresh-repo`, `/rebase-pr`, `/wrap-up`, `/troubleshoot-rebase`, `/troubleshoot-precommit`, `/troubleshoot-worktree`
+- **Skills**: `/sync-main`, `/refresh-repo`, `/rebase-pr`, `/wrap-up`, `/troubleshoot-rebase`, `/troubleshoot-precommit`, `/troubleshoot-worktree`, `/pre-commit-architecture`
 - **Purpose**: Maintain linear git history and keep branches in sync
 
 ### github-workflows
@@ -57,7 +57,7 @@ Git main branch sync, repository refresh, and PR merge workflows.
 PR finalization, squash-merge, review thread resolution, and issue shaping.
 
 - **Type**: Command/Skill-based plugin
-- **Skills**: `/finalize-pr`, `/squash-merge-pr`, `/resolve-pr-threads`, `/shape-issues`, `/trigger-ai-reviews`
+- **Skills**: `/finalize-pr`, `/squash-merge-pr`, `/resolve-pr-threads`, `/shape-issues`, `/trigger-ai-reviews`, `/shared-workflow-org-refs`
 - **Purpose**: GitHub PR/issue management workflows
 
 ### infra-orchestration
@@ -77,7 +77,7 @@ On-demand skill-based plugins that load specific standards as context.
 | **code-standards** | `/code-quality-standards`, `/review-standards` | Code quality, documentation, testing, review guidelines |
 | **git-standards** | `/git-workflow-standards`, `/pr-standards` | Branching, PR creation, issue linking |
 | **infra-standards** | `/infrastructure-standards` | Proxmox, Terraform, Ansible deployment |
-| **project-standards** | `/agentsmd-authoring`, `/workspace-standards`, `/skills-registry` | AgentsMD authoring, workspace, skills registry |
+| **project-standards** | `/agentsmd-authoring`, `/workspace-standards`, `/skills-registry`, `/nix-tool-policy` | AgentsMD authoring, workspace, skills registry, Nix tool policy |
 
 ### pal-health
 

--- a/code-standards/skills/code-quality-standards/SKILL.md
+++ b/code-standards/skills/code-quality-standards/SKILL.md
@@ -27,11 +27,12 @@ description: Use when writing or reviewing code and documentation
 
 ### Bash / Shell
 
-- **NEVER use Bash for file operations** — use Read/Edit/Write/Grep/Glob tools.
+Baseline tool-selection rules are auto-loaded from ai-assistant-instructions
+`agentsmd/rules/tool-use.md`; this skill adds review-time strictness.
+
 - **NEVER use `for` loops** — breaks permission matching, requires interactive
   prompts. Use parallel tool calls or tool-native batch operations instead.
 - **NEVER generate scripts** — execute commands directly via tool calls.
-- Prefer parallel tool calls for independent commands.
 
 ### JavaScript / TypeScript
 

--- a/git-standards/skills/pr-standards/SKILL.md
+++ b/git-standards/skills/pr-standards/SKILL.md
@@ -93,12 +93,12 @@ Exception: explicit requests like
 
 ## Commit, PR Title & PR Description Style
 
-No emoji or gitmoji in commit messages, PR titles, PR descriptions, or
-release notes. Conventional-commit prefixes (`feat:`, `fix:`, `chore:`,
-`docs:`, etc.) are required at the start of commit subjects and PR titles
-only — descriptions and release notes are plain prose.
-Applies to all PRs — human, AI-assisted, and bot-authored automated fixes.
-No `🤖`, no `✨`, no `🐛`. The `type(scope):` prefix carries the signal.
+Canonical conventions (no emoji, Conventional Commits, `feat:` vs `fix:`):
+[docs.jacobpevans.com/conventions/commit-conventions](https://docs.jacobpevans.com/conventions/commit-conventions).
+
+PR-specific additions: prefixes apply to commit subjects and PR titles
+only — PR descriptions and release notes are plain prose. Applies to all
+PRs — human, AI-assisted, and bot-authored automated fixes.
 
 ## GitHub Issue Standards
 

--- a/git-workflows/.claude-plugin/plugin.json
+++ b/git-workflows/.claude-plugin/plugin.json
@@ -13,6 +13,7 @@
     "./skills/troubleshoot-rebase",
     "./skills/troubleshoot-precommit",
     "./skills/troubleshoot-worktree",
-    "./skills/wrap-up"
+    "./skills/wrap-up",
+    "./skills/pre-commit-architecture"
   ]
 }

--- a/git-workflows/README.md
+++ b/git-workflows/README.md
@@ -15,6 +15,7 @@ See [ARCHITECTURE.md](ARCHITECTURE.md) for integration diagrams.
 - **`/troubleshoot-rebase`** - Diagnose and recover from git rebase failures
 - **`/troubleshoot-precommit`** - Troubleshoot pre-commit hook failures and auto-fixes
 - **`/troubleshoot-worktree`** - Troubleshoot git worktree, branch, and refname issues
+- **`/pre-commit-architecture`** - Canonical pre-commit hook architecture: where hook definitions and shared lint configs live
 
 ## Installation
 

--- a/git-workflows/skills/pre-commit-architecture/SKILL.md
+++ b/git-workflows/skills/pre-commit-architecture/SKILL.md
@@ -1,0 +1,136 @@
+---
+name: pre-commit-architecture
+description: Use when adding or editing .pre-commit-config.yaml, wiring pre-commit hooks into a repo, scaffolding a new repo's lint/hook setup, or deciding where a hook or shared lint config should live. Covers the canonical nix-devenv/dryvist-.github architecture, profiles, and consumer patterns.
+---
+
+# Pre-Commit Architecture
+
+Single canonical home per artifact. No per-repo duplication of hook
+definitions or shared lint configs.
+
+| Artifact | Canonical home | How consumers pull it |
+| --- | --- | --- |
+| Pre-commit hook definitions (Nix consumers) | [`dryvist/nix-devenv`](https://github.com/dryvist/nix-devenv) — `lib/pre-commit-hooks.nix` + `flake-modules/profiles/<name>.nix` | `imports = [ inputs.nix-devenv.flakeModules.<profile> ]` in the consumer's `flake.nix` |
+| Pre-commit hook definitions (non-Nix consumers) | [`dryvist/.github`](https://github.com/dryvist/.github) `precommit/templates/<profile>.yaml` | Copy at scaffold; Renovate keeps `rev:` pins fresh |
+| Shared lint configs (`.markdownlint-cli2.yaml`, `.tflint.hcl`, `.ansible-lint`, `.yamllint.yml`) | `dryvist/.github` — `.markdownlint-cli2.yaml` at root for backward compat; the rest in `precommit/configs/` | Nix path: `nix-devenv.lib.fetch-shared-configs` materializes nix-store paths; non-Nix path: copy at scaffold |
+| `zizmor.yml` workflow-security policy | `dryvist/.github` at the root | Same as above — passed as `--config` by the base profile's zizmor hook |
+
+## Profiles
+
+`nix-devenv` exports six profile names. Pick one per consumer repo.
+
+| Profile | Adds on top of base hygiene | Inventory match |
+| --- | --- | --- |
+| `base` | Nothing — exposes the base wiring (deadnix, statix, check-yaml/toml/json, check-merge-conflict, check-added-large-files=500k, end-of-file-fixer, trim-trailing-whitespace, detect-private-keys, markdownlint-cli2, zizmor, treefmt) | Generic repos |
+| `nix` | Alias for `base` (deadnix and statix file-glob to `.nix` automatically) | nix-* repos |
+| `markdown` | Alias for `base` (markdownlint-cli2 file-globs to `.md` automatically) | Markdown-heavy repos |
+| `terraform` | `terraform-format`, `terraform-validate`, `tflint` | `terraform-*`, `tofu-*` |
+| `ansible` | `ansible-lint`, `yamllint` | `ansible-*` |
+| `python` | `ruff`, `ruff-format`, `mypy` | python-template, mlx-benchmarks, etc. |
+
+The base wiring already covers Nix lints (`deadnix`, `statix`) and
+markdown (`markdownlint-cli2`); `git-hooks.nix`'s file-glob filters
+make those hooks inert on repos that don't have the matching file
+types. So `base`, `nix`, and `markdown` are deliberately identical
+modules — the name signals intent to the reader, not behavior.
+
+## Consumer pattern (Nix path, preferred)
+
+```nix
+# flake.nix in a consumer repo
+{
+  inputs = {
+    nixpkgs.url = "github:nixos/nixpkgs/nixpkgs-25.11-darwin";
+    flake-parts.url = "github:hercules-ci/flake-parts";
+    nix-devenv = {
+      url = "github:dryvist/nix-devenv";
+      inputs.nixpkgs.follows = "nixpkgs";
+    };
+  };
+
+  outputs =
+    inputs@{ flake-parts, nix-devenv, ... }:
+    flake-parts.lib.mkFlake { inherit inputs; } {
+      systems = [
+        "aarch64-darwin"
+        "x86_64-darwin"
+        "x86_64-linux"
+        "aarch64-linux"
+      ];
+      imports = [ nix-devenv.flakeModules.terraform ];
+
+      perSystem =
+        { system, ... }:
+        {
+          devShells.default = nix-devenv.devShells.${system}.terraform;
+        };
+    };
+}
+```
+
+Scaffold a new repo with this layout via
+`nix flake init -t github:JacobPEvans/nix-devenv#with-hooks`.
+
+## Consumer pattern (non-Nix path)
+
+```bash
+# Pick the matching profile template
+gh api repos/dryvist/.github/contents/precommit/templates/terraform.yaml \
+  -H "Accept: application/vnd.github.raw" > .pre-commit-config.yaml
+
+# Materialize the configs the hooks need
+gh api repos/dryvist/.github/contents/precommit/configs/tflint.hcl \
+  -H "Accept: application/vnd.github.raw" > .tflint.hcl
+gh api repos/dryvist/.github/contents/.markdownlint-cli2.yaml \
+  -H "Accept: application/vnd.github.raw" > .markdownlint-cli2.yaml
+gh api repos/dryvist/.github/contents/zizmor.yml \
+  -H "Accept: application/vnd.github.raw" > zizmor.yml
+
+pre-commit install
+```
+
+## Rules for AI agents
+
+- Do NOT add hook definitions to consumer-repo `.pre-commit-config.yaml`
+  files. If the canonical profile doesn't cover something, add it to
+  `nix-devenv`'s base profile (in `lib/pre-commit-hooks.nix`) or the
+  matching profile (in `flake-modules/profiles/<name>.nix`), then pull
+  it through everywhere on the next `nix flake update`.
+- Do NOT duplicate shared lint config files (`.markdownlint`,
+  `.tflint.hcl`, `.ansible-lint`, `.yamllint`) into a new repo. Pull
+  them via the Nix path (`fetch-shared-configs`) or copy from
+  `dryvist/.github` at scaffold (non-Nix path).
+- When opening a PR that adopts the architecture in a new consumer
+  repo, the diff is approximately: add `flake.nix` + `flake.lock`,
+  modify `.envrc`, delete `.pre-commit-config.yaml`, delete the
+  duplicated lint config files that the canonical now covers.
+- Hook versions are pinned via `flake.lock` (Nix path) or `rev:`
+  strings in the static template (non-Nix path). Do NOT pin versions
+  per-repo unless overriding a specific consumer.
+- See [`precommit/README.md` in `dryvist/.github`](https://github.com/dryvist/.github/blob/main/precommit/README.md)
+  for the architecture rationale, canonical-config choices, and the
+  trade-offs behind why certain hooks (checkov, bandit, detect-secrets)
+  stay opt-in per repo.
+
+## Known limitations (as of 2026-05-31)
+
+- `cachix/git-hooks.nix`'s built-in `tflint` wrapper drops args beyond
+  `$1`, so the `terraform` profile's `--config <sharedConfigs.tflint>`
+  plumbing doesn't reach tflint. Consumers either keep a synced copy of
+  the canonical `.tflint.hcl` in the repo (tflint's local-config
+  discovery still finds it) or override `tflint.args` to `lib.mkForce
+  [ ]`. An upstream fix to the wrapper would let
+  `fetch-shared-configs` drive tflint config directly.
+- `terraform-validate` hooks need network access to `tofu init`
+  external modules. `nix flake check` runs hooks in a sandboxed
+  environment without network. Repos with external module references
+  override `terraform-validate.enable = lib.mkForce false` for the
+  flake-check path and rely on CI's OIDC-authenticated
+  `terragrunt validate` to cover the check.
+- `gitleaks` is not in `cachix/git-hooks.nix`'s built-in hook set yet.
+  Consumers that want it wire it as a custom hook locally; a follow-up
+  adds it to the base profile.
+
+## Related Skills
+
+- **troubleshoot-precommit** (git-workflows) — Troubleshoot pre-commit hook failures and auto-fixes

--- a/git-workflows/skills/troubleshoot-precommit/SKILL.md
+++ b/git-workflows/skills/troubleshoot-precommit/SKILL.md
@@ -76,5 +76,6 @@ git diff HEAD~1   # See what the hook is trying to fix
 
 ## Related Skills
 
+- **pre-commit-architecture** (git-workflows) — Where hook definitions and shared lint configs live
 - **troubleshoot-rebase** (git-workflows) — Diagnose and recover from git rebase failures
 - **troubleshoot-worktree** (git-workflows) — Troubleshoot git worktree, branch, and refname issues

--- a/github-workflows/.claude-plugin/plugin.json
+++ b/github-workflows/.claude-plugin/plugin.json
@@ -17,6 +17,7 @@
     "./skills/gh-cli-patterns",
     "./skills/shape-issues",
     "./skills/resolve-pr-threads",
-    "./skills/trigger-ai-reviews"
+    "./skills/trigger-ai-reviews",
+    "./skills/shared-workflow-org-refs"
   ]
 }

--- a/github-workflows/README.md
+++ b/github-workflows/README.md
@@ -15,6 +15,7 @@ See [ARCHITECTURE.md](ARCHITECTURE.md) for integration diagrams and the master s
 - **`/gh-cli-patterns`** - Canonical reference for gh CLI command shapes used by other skills in this plugin
 - **`/shape-issues`** - Shape raw ideas into actionable GitHub Issues using Shape Up methodology
 - **`/trigger-ai-reviews`** - Trigger Claude, Gemini, and Copilot reviews on a PR
+- **`/shared-workflow-org-refs`** - Literal current-owner `uses:` references for reusable workflows; shared-CI homes under dryvist
 
 ## Installation
 

--- a/github-workflows/skills/shared-workflow-org-refs/SKILL.md
+++ b/github-workflows/skills/shared-workflow-org-refs/SKILL.md
@@ -1,0 +1,57 @@
+---
+name: shared-workflow-org-refs
+description: "Use when creating or editing GitHub Actions workflows that call reusable workflows (uses: OWNER/repo/.github/workflows/...) — org owner references must be the literal current org, and shared-CI homes are under dryvist."
+---
+
+# Shared Workflow Org References
+
+GitHub Actions reusable-workflow and action `uses:` clauses are the one place the
+"don't rewrite `JacobPEvans/*` on sight — the redirect holds" rule does NOT apply.
+
+Two hard GitHub constraints:
+
+- `uses:` cannot contain expressions or variables — the owner is always a literal.
+  `uses: ${{ vars.X }}/repo/...@ref` is rejected. No org variable can centralize it.
+- `uses:` does NOT follow repository transfer/rename redirects (by design). API, git, and the browser DO follow them; Actions does not.
+
+Consequence: when a shared-CI repo changes orgs, every consumer's `uses:` fails at parse time
+(the run shows zero jobs and "workflow was not found"). There is no runtime variable that prevents this.
+
+## Canonical home: dryvist
+
+**dryvist is the canonical home for everything dryvist uses.** Anything a dryvist
+repo consumes — reusable workflows, presets, policies — belongs under `dryvist/*`.
+`JacobPEvans-personal/*` may depend on `dryvist/*`; `dryvist/*` must **never** depend
+on `JacobPEvans-personal/*`. When a shared workflow is used by dryvist, its home is
+`dryvist/.github` (or the relevant `dryvist/*` repo), not the personal account.
+
+Because `uses:` does not follow redirects, reference each workflow by its literal
+**current** owner from the table below until a pending relocation actually lands.
+
+| Shared-CI workflow set | Current home | Status |
+| --- | --- | --- |
+| `ai-workflows` reusable workflows | `dryvist/ai-workflows` | canonical |
+| Nix reusable workflows (`_nix-validate.yml`, `_nix-build.yml`) | `dryvist/.github` | canonical |
+| Release-please (`_release-please.yml`) | `dryvist/.github` | canonical — org-native (dryvist release App, major-bump block, auto-merge) |
+| `_markdown-lint`, `_file-size`, `_osv-scan`, `_ci-gate`, … | `JacobPEvans-personal/.github` | **pending relocation to `dryvist/.github`** |
+
+Nix and release-please were deliberately relocated to `dryvist/.github` (the org owns
+its own CI). The remaining non-Nix `.github` workflows are still in
+`JacobPEvans-personal/.github` **only until they are moved the same way** — that is a
+transitional home, not a permanent one. Repoint consumers via the sweep below as each
+moves; do not move any back to the personal account.
+
+## Rules
+
+- In `uses:`, always reference the literal current owner above.
+- Do NOT replace a reusable-workflow call with a `gh workflow run` / checkout `vars.*` dispatcher
+  just to gain a variable: that loses required-check status, inputs/outputs, and `secrets: inherit`.
+- gh-aw `{{#import ...}}` references and compiled `*.lock.yml` files resolve at compile time
+  via the redirect — leave them to the don't-rewrite rule and gh-aw recompilation.
+
+## If a shared-CI repo must move anyway (sweep)
+
+1. `gh search code 'OLD_OWNER/REPO' --owner dryvist` (and `--owner JacobPEvans-personal`), filtered to `.github/workflows/*.yml`.
+2. Per consumer repo: swap only the `uses:` owner segment, preserving path and `@ref`; one PR per repo.
+3. Skip `*.lock.yml`, `{{#import}}`, and docs.
+4. Token tiers: dryvist repos → DRYVIST; JacobPEvans-personal repos → PRIVATE.

--- a/project-standards/.claude-plugin/plugin.json
+++ b/project-standards/.claude-plugin/plugin.json
@@ -11,6 +11,7 @@
   "skills": [
     "./skills/agentsmd-authoring",
     "./skills/workspace-standards",
-    "./skills/skills-registry"
+    "./skills/skills-registry",
+    "./skills/nix-tool-policy"
   ]
 }

--- a/project-standards/README.md
+++ b/project-standards/README.md
@@ -9,6 +9,7 @@ See [ARCHITECTURE.md](ARCHITECTURE.md) for integration diagrams.
 - **`/agentsmd-authoring`** - File structure, token targets, two-tier architecture, frontmatter templates
 - **`/workspace-standards`** - Cross-project standards, git workflow, security, cost management
 - **`/skills-registry`** - Lookup table for all available tools, skills, commands, agents, plugins
+- **`/nix-tool-policy`** - Never install tools that Nix dev shells provide; use the dev shell or a temporary nix shell
 
 ## Installation
 

--- a/project-standards/skills/nix-tool-policy/SKILL.md
+++ b/project-standards/skills/nix-tool-policy/SKILL.md
@@ -1,0 +1,65 @@
+---
+name: nix-tool-policy
+description: Use when installing or choosing CLI tools in a Nix flake repo, editing flake.nix or home-manager config, or when tempted to pip/pipx/uv/brew/npm install anything. Tools come from the dev shell or nix shell — never ad-hoc package managers.
+---
+
+# Nix Tool Policy
+
+## Rule: Never Install Tools That Nix Dev Shells Provide
+
+**Scope**: All repositories with `flake.nix` + `.envrc` (Nix dev shell pattern)
+
+## Prohibited Actions
+
+- `pipx install <tool>` / `pipx reinstall <tool>` — pipx virtualenvs reference Nix store Python; breaks after GC
+- `pip install <tool>` / `pip3 install <tool>` — same problem, also pollutes global Python
+- `uv pip install <tool>` — same Nix store Python problem
+- `uv run <tool>` — generally unnecessary in Nix dev shells; prefer bare commands from the dev shell PATH.
+  Last-resort package runner (with confirmation) only when the dev shell does not provide the tool.
+- `brew install <tool>` for tools already in the dev shell — creates version conflicts
+
+## What To Do Instead
+
+1. **Tools are on PATH**: When a repo has `flake.nix` + `.envrc`, all project tools are provided by the Nix dev shell. Run them as bare commands.
+
+2. **If a tool is not found**: Use `direnv exec . <command>` to run within the dev shell environment. This works even when direnv shell hooks haven't fired.
+
+3. **If direnv exec fails**: Use `nix develop --command <command>` as a fallback. This is slower but always works.
+
+4. **If the tool truly isn't in the flake**: Prefer adding the tool to `flake.nix` so it becomes part of the dev shell.
+   For one-off usage, run it via `nix shell -p <tool>` rather than installing with pipx/pip/uv.
+
+5. **Never install globally**: Do not respond to a missing tool by installing it system-wide with pipx/pip/uv/brew;
+   use the dev shell or a temporary Nix invocation, and update `flake.nix` when the tool is needed long term.
+
+## Nix-Specific Alternatives
+
+| Task | Use This | Not This |
+| --- | --- | --- |
+| Config generation | Nix functions (`lib.mkIf`, `lib.generators.*`) | Shell/Python generator |
+| Nix data processing | `builtins.fromJSON`, `builtins.readFile`, `lib.strings.*` | Python wrapper |
+
+## Nix Script Patterns
+
+When a Nix script IS needed (committed artifact):
+
+- Use `writeShellApplication` with `runtimeInputs`, reference via `${./<relative-path>}`
+- For inline Nix wrappers: one-liner `exec` patterns in `writeShellScriptBin` are acceptable
+
+## Why This Matters
+
+Nix manages Python interpreters in the Nix store (`/nix/store/...`).
+Tools installed via pipx/pip create virtual environments that hardcode paths to these interpreters.
+When `nix-collect-garbage` runs or a flake update changes the Python version,
+those paths become invalid and every pipx/pip-installed tool breaks silently.
+
+The Nix dev shell pattern avoids this by providing tools through the flake lockfile, ensuring consistent, reproducible environments that survive garbage collection.
+
+## Repos Using This Pattern
+
+All JacobPEvans repositories with `flake.nix` + `.envrc`, including:
+
+- ansible-proxmox, ansible-proxmox-apps, ansible-splunk
+- terraform-proxmox, terraform-aws, terraform-aws-bedrock
+- nix-darwin, nix-ai, nix-home, nix-devenv
+- orbstack-kubernetes

--- a/project-standards/skills/skills-registry/SKILL.md
+++ b/project-standards/skills/skills-registry/SKILL.md
@@ -16,6 +16,9 @@ description: Use when looking up available tools, skills, commands, agents, or p
 | Troubleshoot rebase | `/troubleshoot-rebase` | `git-workflows` | Recover failures |
 | Troubleshoot worktrees | `/troubleshoot-worktree` | `git-workflows` | Fix refname |
 | Troubleshoot pre-commit | `/troubleshoot-precommit` | `git-workflows` | Fix hooks |
+| Pre-commit architecture | `/pre-commit-architecture` | `git-workflows` | Hook/config homes |
+| Shared workflow org refs | `/shared-workflow-org-refs` | `github-workflows` | Literal `uses:` owners |
+| Nix tool policy | `/nix-tool-policy` | `project-standards` | No ad-hoc installs |
 | Manage your PR | `/finalize-pr` | `github-workflows` | PR author flow (`all`/`org` for multi-repo) |
 | Create GitHub issues | `/shape-issues` | `github-workflows` | Shape Up method |
 | Resolve PR threads | `/resolve-pr-threads` | `github-workflows` | Thread resolution |


### PR DESCRIPTION
## Summary

### Part 1: three new on-demand skills (migrated from always-loaded rules)

Three situational rules in `ai-assistant-instructions` cost ~3.2k tokens every session but apply only when their topic comes up. They become self-contained progressive-disclosure skills here:

| Source rule (ai-assistant-instructions) | New skill |
| --- | --- |
| `agentsmd/rules/pre-commit.md` | `git-workflows/skills/pre-commit-architecture` |
| `agentsmd/rules/nix-tool-policy.md` | `project-standards/skills/nix-tool-policy` |
| `agentsmd/rules/shared-workflow-org-refs.md` | `github-workflows/skills/shared-workflow-org-refs` |

Each plugin's `plugin.json` skills list, plugin README, root README, and the `skills-registry` lookup table are updated to match (skills are listed explicitly in this repo — no auto-discovery). `troubleshoot-precommit` gains a reciprocal Related Skills link to `pre-commit-architecture`. No version bumps — release-please owns those.

### Part 2: de-drift two existing skills

- `code-standards/skills/code-quality-standards`: deleted the restated tool-use baseline ("NEVER use Bash for file operations", parallel-calls line) — that baseline auto-loads from `agentsmd/rules/tool-use.md`. Kept only the stricter review-time deltas (for-loop ban, no-script-generation) plus a pointer line to the canonical rule.
- `git-standards/skills/pr-standards`: replaced the duplicated commit-convention prose with a pointer to <https://docs.jacobpevans.com/conventions/commit-conventions> (canonical), keeping only the PR-specific additions (prefixes apply to commit subjects and PR titles only; applies to bot-authored PRs too). PR-creation guards and workaround-classification sections untouched.

## Ordering

ai-assistant-instructions will delete the migrated rules in a follow-up PR **after this releases** — the skills above are self-contained so nothing breaks in the gap.

Refs: JacobPEvans/ai-assistant-instructions#678

## Test plan

- [x] `markdownlint-cli2` on all 11 changed markdown files — 0 errors
- [x] `agentskills validate` (skills-ref 0.1.1, same as CI) on all 7 new/changed skills — all valid (caught and fixed an unquoted `uses:` in the shared-workflow-org-refs description frontmatter)
- [x] Progressive-disclosure line limits: largest new skill is 136 lines (limit 500)
- [x] `jq` parse check on the three edited `plugin.json` files
- [ ] CI `validate-plugin` (dotcommander/cclint) — local `cclint` is a different tool; covered by CI

🤖 Generated with [Claude Code](https://claude.com/claude-code)