### PR TITLE
chore(config-management): deprecate permission-sync/quick-add-permission skills

### DIFF
--- a/config-management/rules/permission-format.md
+++ b/config-management/rules/permission-format.md
@@ -1,10 +1,16 @@
 ---
 description: Permission format rules for AI tool settings — enforces Bash(command *) space-wildcard format
 globs:
-  - "agentsmd/permissions/**"
+  - "data/permissions/**"
 ---
 
 # Permission Format
+
+> Permissions now live in
+> [`dryvist/nix-claude-code` → `data/permissions/`](https://github.com/dryvist/nix-claude-code/tree/main/data/permissions)
+> (the `agentsmd/permissions/` JSON tree was retired — see
+> `dryvist/ai-assistant-instructions#680`). The format rules below still apply to
+> the `.nix` data.
 
 ## Generated Format
 
@@ -20,15 +26,16 @@ The `:*` suffix format is deprecated per Claude Code documentation.
 
 ## Source Format
 
-Source JSON files in `agentsmd/permissions/` store bare commands with no suffix:
+Source `.nix` files in `nix-claude-code/data/permissions/` store bare commands
+with no suffix:
 
-```json
+```nix
 {
-  "commands": [
-    "git",
-    "docker exec",
+  commands = [
+    "git"
+    "docker exec"
     "pytest"
-  ]
+  ];
 }
 ```
 

--- a/config-management/skills/quick-add-permission/SKILL.md
+++ b/config-management/skills/quick-add-permission/SKILL.md
@@ -1,69 +1,29 @@
 ---
 name: quick-add-permission
-description: Quickly add always-allow permissions to all AI tool permission lists
+description: "DEPRECATED — permissions moved to nix-claude-code; edit data/permissions/*.nix there instead of this repo's JSON"
 ---
 
-# Quick Add Permission
+# Quick Add Permission (deprecated)
 
-Quickly add one or more always-allow permissions to all AI tool permission lists (Claude, Gemini, etc.) with a fresh worktree off the latest main.
+> **Deprecated.** This skill added always-allow entries to
+> `ai-assistant-instructions/agentsmd/permissions/{allow,ask,deny}.json` and the
+> `.gemini/permissions/` mirror. That JSON tree has been **deleted**.
 
-## Parameters
+## What to do instead
 
-The command accepts optional permission(s) as arguments in flexible formats:
+To add a permission, edit the Nix data in
+[`dryvist/nix-claude-code` → `data/permissions/`](https://github.com/dryvist/nix-claude-code/tree/main/data/permissions)
+and open a PR there:
 
-```text
-/quick-add-permission
-/quick-add-permission "docker ps"
-/quick-add-permission "docker ps" "docker logs" "kubectl get"
-/quick-add-permission "Bash(docker ps *)"
-```
+- `allow.nix` — auto-approved commands (bare command, no trailing `*` — the
+  formatter appends the space-wildcard).
+- `ask.nix` — commands that prompt first.
+- `deny.nix` — hard-blocked commands.
+- `domains.nix` — `WebFetch` domains.
 
-If no arguments provided, the command will prompt interactively.
+`nix-ai` reads this via `nix-claude-code.lib.permissions` and renders the
+per-tool settings (Claude / Codex / Gemini / Copilot). The project is also
+moving to an **auto-mode classifier**, where novel commands are governed by
+intent at runtime rather than by a static allow-list.
 
-### Input Format Detection
-
-The command intelligently converts simple inputs to proper permission format:
-
-- `"docker ps"` -> `"Bash(docker ps *)"`
-- `"git status"` -> `"Bash(git status *)"`
-- `"kubectl get pods"` -> `"Bash(kubectl get pods *)"`
-- `"Bash(docker ps *)"` -> Used as-is (already formatted)
-
-## Steps
-
-### 1. Sync Main and Create Worktree
-
-Sync main and create worktree with branch name: `chore/add-permissions-$(date +%Y%m%d-%H%M%S)`.
-
-### 2. Gather and Format Permission Input
-
-- Parse arguments or prompt interactively
-- Convert plain text to `Bash(command *)` format
-- Use as-is if already formatted with parentheses
-- Confirm format with user
-
-### 3. Update Permission Files
-
-Files: `agentsmd/permissions/{allow,ask,deny}.json`, `.gemini/permissions/{allow,deny}.json`
-
-For each permission:
-
-1. Read existing JSON, check for duplicates
-2. Add new permission, maintain alphabetical order
-3. Sync across all AI tools
-4. Verify JSON validity with `jq empty`
-
-### 4. Summary
-
-Report: worktree, branch, permissions added, files modified, next steps.
-
-## Notes
-
-- Fresh worktree from latest main
-- Sync across all AI tools
-- Maintain alphabetical ordering
-- Skip duplicates, verify JSON
-
-## Related Skills
-
-- sync-permissions (config-management)
+See `dryvist/ai-assistant-instructions#680` for the migration.

--- a/config-management/skills/sync-permissions/SKILL.md
+++ b/config-management/skills/sync-permissions/SKILL.md
@@ -1,53 +1,25 @@
 ---
 name: sync-permissions
-description: Merge local AI permission settings into repository-wide permissions
+description: "DEPRECATED — permission sync is retired; permissions now live in nix-claude-code and are governed by the auto-mode classifier"
 ---
 
-# Sync Permissions
+# Sync Permissions (deprecated)
 
-Scan local AI settings across all repos/worktrees, analyze permissions, and merge approved changes into repository permissions.
+> **Deprecated.** This skill swept local `settings.local.json` files and merged
+> approved permissions back into `ai-assistant-instructions/agentsmd/permissions/`.
+> That JSON tree has been **deleted** and the local-sweep workflow (the
+> `permission-sync` routine that did the same job) has been retired.
 
-## Supported Tools
+## What to do instead
 
-| AI Tool | Config Location | Sync Status |
-| --- | --- | --- |
-| Claude | `agentsmd/permissions/` | Fully supported |
-| Gemini | `.gemini/permissions/` | Fully supported |
-| Copilot | `.github/copilot-instructions.md` | Not yet supported |
+- **Source of truth:** tool permissions now live in
+  [`dryvist/nix-claude-code` → `data/permissions/`](https://github.com/dryvist/nix-claude-code/tree/main/data/permissions)
+  (`allow.nix` / `ask.nix` / `deny.nix` / `domains.nix`). `nix-ai` renders them
+  into each tool's settings. To change a permission, edit the `.nix` data and
+  open a PR there.
+- **Going forward:** the project is moving to an **auto-mode classifier** —
+  novel commands are governed by intent at runtime rather than by an
+  ever-growing static allow-list, so a periodic merge-local-overrides step is
+  no longer needed.
 
-## Workflow
-
-### Phase 1: Discovery and Analysis
-
-Scan home directory for AI permission settings, classify permissions, and deduplicate against existing patterns.
-
-**Currently scans:**
-
-- Claude settings from `~/.claude/settings.local.json` in all repos/worktrees
-- Gemini settings from `~/.gemini/settings.json` in all repos/worktrees
-
-### Phase 2: User Approval
-
-Review analysis report. Ask user to approve, modify, or cancel.
-
-### Phase 3: Execution
-
-**Only after approval**, apply changes, sync across tools, and cleanup local files.
-
-**Sync strategy:**
-
-- Merge permissions using a union approach
-- When same permission exists in both tools with different classifications, prioritize Claude classification
-- When permission exists only in Gemini, preserve and propagate to Claude
-- Result: identical permission sets across all supported tools
-
-## Architecture
-
-Command -> Agent -> Skill pattern:
-
-- Agents: `permissions-analyzer`, `permissions-syncer`
-- Skill: `permission-patterns` (safety classification, deduplication, token-efficient extraction)
-
-## Related Skills
-
-- quick-add-permission (config-management)
+See `dryvist/ai-assistant-instructions#680` for the migration.


### PR DESCRIPTION
## What

Deprecates the two `config-management` permission skills. They wrote always-allow / sync changes into `ai-assistant-instructions/agentsmd/permissions/*.json` — a tree that has been **deleted** (dryvist/ai-assistant-instructions#686). Permissions now live in `nix-claude-code/data/permissions/*.nix`, and the project is moving to an auto-mode classifier.

These skills are JSON-native (jq, `{"commands":[...]}`), so repointing them at Nix attribute sets would be a full rewrite — not worth it for a retired paradigm (decision recorded in #680).

## Changes

- `skills/sync-permissions/SKILL.md`, `skills/quick-add-permission/SKILL.md`: rewritten as deprecation stubs that point to `nix-claude-code` + the auto-mode direction, and remove the now-broken instructions to write `agentsmd/permissions/*.json`. Frontmatter `description` prefixed `DEPRECATED`.
- `rules/permission-format.md`: repointed `globs` and the Source-Format example from JSON to the `nix-claude-code` `.nix` data. The format rules (space-wildcard, `deny > ask > allow`, nix-first) still apply.

Registration in `plugin.json` / `marketplace.json` left intact so existing references don't 404; release-please will bump `config-management`.

## Verification

- Repo pre-commit passes, including **Validate agent skills** and **Validate plugin frontmatter (cclint)**.

Refs: dryvist/ai-assistant-instructions#680, #686

🤖 Generated with [Claude Code](https://claude.com/claude-code)