### PR TITLE
docs(readme): make standalone — drop cross-repo narrative, link the hub

### DIFF
--- a/README.md
+++ b/README.md
@@ -261,58 +261,6 @@ git config core.hooksPath .githooks
 git config --unset core.hooksPath
 ```
 
-## Repository Integration
-
-### Nix Flake Auto-Update
-
-This repository automatically triggers Nix flake updates when changes are merged to main.
-This ensures downstream repositories (like [nix-config](https://github.com/JacobPEvans/nix))
-immediately pull in plugin updates instead of waiting for scheduled updates.
-
-#### How It Works
-
-1. Changes merged to `main` branch trigger `.github/workflows/trigger-nix-update.yml`
-2. Workflow sends a `repository_dispatch` event to the nix repository
-3. Nix repository's `deps-update-flake.yml` workflow updates the `claude-code-plugins` flake input
-4. Automated PR created with the updated `flake.lock`
-
-#### Organization Secret Required
-
-The trigger workflow requires a GitHub Personal Access Token (PAT) stored as an organization secret:
-
-**Secret Name**: `GH_PAT_WORKFLOW_DISPATCH`
-
-**Required Scopes**:
-
-- `repo` - Full control of private repositories
-- `workflow` - Update GitHub Action workflows
-
-**Setup Instructions**:
-
-1. Generate PAT: GitHub.com → Settings → Developer settings → Personal access tokens → Tokens (classic)
-2. Select required scopes: `repo` and `workflow`
-3. Set expiration to 1 year
-4. Copy the token
-5. Add as organization secret: Organization Settings → Secrets and variables → Actions → New organization secret
-6. Name: `GH_PAT_WORKFLOW_DISPATCH`
-7. Paste token value
-8. Select repository access (all repositories or specific repos)
-
-**Security Notes**:
-
-- Token has minimal scopes (no admin, no packages)
-- Rotate token annually before expiration
-- Never expose token in logs or workflow outputs
-- Organization-level secret is accessible to all repos
-
-#### Reusable Pattern
-
-This pattern can be replicated to any JacobPEvans repository that's a flake input. Simply:
-
-1. Copy `.github/workflows/trigger-nix-update.yml` to the target repository
-2. Update the `flake_input_name` field to match the flake input name in `nix/flake.nix`
-3. No changes needed to the nix repository workflow (uses generic event type)
-
 ## License
 
 Apache License 2.0 - See [LICENSE](LICENSE) for details.
@@ -323,3 +271,7 @@ JacobPEvans
 
 - GitHub: [@JacobPEvans](https://github.com/JacobPEvans)
 - Email: <20714140+JacobPEvans@users.noreply.github.com>
+
+---
+
+> Part of a [larger ecosystem of ~40 repos](https://docs.jacobpevans.com) — see how it all fits together.


### PR DESCRIPTION
## Summary

Per the [README standard](https://docs.jacobpevans.com/conventions/readme-conventions): removed the **Repository Integration** section, which documented cross-repo wiring (how merges trigger a `repository_dispatch` to the Nix flake consumer repo, the org PAT setup, and the reusable pattern for other flake-input repos). That connective story lives on the hub. Added the single hub footer. Installation/Usage already present; no config.

## Linear

JAC-141

## Test plan

- [x] grep: no sibling-repo references remain
- [x] Installation + Usage present