### PR TITLE
chore: remove AI merge-prohibition and human-review-gate language

### DIFF
--- a/ai-delegation/skills/auto-maintain/SKILL.md
+++ b/ai-delegation/skills/auto-maintain/SKILL.md
@@ -31,7 +31,7 @@ gh pr list --author @me --state open --json number | jq length
    1. PRs behind main (/sync-main)
    2. Failing CI (/finalize-pr)
    3. Review comments (/resolve-pr-threads)
-   4. PRs ready to merge (/refresh-repo) - Report readiness, do NOT merge
+   4. PRs ready to merge (/refresh-repo)
    --- BLOCKED IN PR-FOCUS MODE ---
    5-10. Bugs, issues, code analysis, docs, tests, deps
 3. DISPATCH - Use subagents (parallel in PR-focus, sequential otherwise; invoke `superpowers:dispatching-parallel-agents`)
@@ -43,7 +43,7 @@ gh pr list --author @me --state open --json number | jq length
 ## Sub-Agent Instructions
 
 Include: ONE task per PR (<200 lines), may spawn helpers, report files/PR/blockers, NEVER ask questions,
-always add `ai:created` label to new issues. **NEVER merge PRs automatically** - report readiness instead.
+always add `ai:created` label to new issues.
 
 ## Forbidden
 
@@ -57,7 +57,7 @@ always add `ai:created` label to new issues. **NEVER merge PRs automatically** -
 
 ## PR Lifecycle
 
-Create PR within 60s of first commit -> fix CI -> resolve threads -> 60s quiet period -> report readiness -> wait for user merge -> remove worktree.
+Create PR within 60s of first commit -> fix CI -> resolve threads -> 60s quiet period -> report readiness -> remove worktree.
 
 ## Resilience
 

--- a/github-workflows/README.md
+++ b/github-workflows/README.md
@@ -6,7 +6,7 @@ See [ARCHITECTURE.md](ARCHITECTURE.md) for integration diagrams and the master s
 
 ## Skills
 
-- **`/ship`** - Full automation: commit, push, create PR(s), and auto-finalize in one command. Never merges.
+- **`/ship`** - Full automation: commit, push, create PR(s), and auto-finalize in one command.
 - **`/finalize-pr`** - Finalize PRs for merge: single PR, all repo PRs (`all`), or all org PRs (`org`). Includes bot-authored PRs in all modes.
 - **`/refresh-repo`** - Check PR merge-readiness, sync local repo, and cleanup stale worktrees
 - **`/rebase-pr`** - Merge a PR using local git rebase + signed commits + push to main

--- a/github-workflows/skills/finalize-pr/SKILL.md
+++ b/github-workflows/skills/finalize-pr/SKILL.md
@@ -20,18 +20,17 @@ No manual intervention required. For manual review-focused workflows, use `/revi
 
 ## Critical Rules
 
-1. **Wait for user approval to merge** - Report ready status, then pause for user merge command
-2. **Verify all checks pass via Phase 3 gate** - Re-run Phase 3 against live API on every
+1. **Verify all checks pass via Phase 3 gate** - Re-run Phase 3 against live API on every
    invocation; "mergeable" means git-conflict-free only, not fully unblocked.
-3. **Resolve all conversations** - Automatically invoke `/resolve-pr-threads` for review threads
-4. **Fix all CodeQL violations** - Check repository and automatically fix using `/resolve-codeql`
-5. **Simplify all code changes** - Invoke /simplify at Step 2.3.5 (after all fixes). Pre-push simplification is handled by `/ship`.
-6. **Validate locally before pushing** - Run project linters and tests
-7. **Monitor CI early, block last** - Start CI monitoring in background immediately, but fix other issues while it runs
-8. **Update PR metadata automatically** - Before reporting ready, update title, description, and linked issues via haiku subagent
-9. **Take direct action** - Identify issues and fix them automatically (except merge decisions)
-10. **Include bot PRs** - Never filter by author. All modes include dependabot, release-please, claude, github-actions, etc.
-11. **Never cross org boundaries** - Org mode derives owner from current repo only
+2. **Resolve all conversations** - Automatically invoke `/resolve-pr-threads` for review threads
+3. **Fix all CodeQL violations** - Check repository and automatically fix using `/resolve-codeql`
+4. **Simplify all code changes** - Invoke /simplify at Step 2.3.5 (after all fixes). Pre-push simplification is handled by `/ship`.
+5. **Validate locally before pushing** - Run project linters and tests
+6. **Monitor CI early, block last** - Start CI monitoring in background immediately, but fix other issues while it runs
+7. **Update PR metadata automatically** - Before reporting ready, update title, description, and linked issues via haiku subagent
+8. **Take direct action** - Identify issues and fix them automatically
+9. **Include bot PRs** - Never filter by author. All modes include dependabot, release-please, claude, github-actions, etc.
+10. **Never cross org boundaries** - Org mode derives owner from current repo only
 
 ## Phase 1: PR Discovery and Targeting
 
@@ -228,13 +227,7 @@ Proceed to Phase 5.
 
 **Single/current-branch mode**: Emit the **Canonical PR Status Summary** (Section 1 =
 this PR, Section 2 = all open PRs in current repo) as defined in /gh-cli-patterns,
-titled `PR Status`. Then append:
-
-```text
-IMPORTANT: Do NOT merge this PR. Wait for the human to review and invoke
-  /squash-merge-pr    # Squash all commits into one
-  /rebase-pr          # Rebase commits onto main (preserves history)
-```
+titled `PR Status`.
 
 **Multi-PR mode**: Record the per-PR result (ready / blocked / needs-human). Restore the original
 branch and continue to the next PR. Do NOT emit a ready report — that happens in Phase 6.
@@ -245,8 +238,6 @@ MUST NOT return until ALL conditions pass for EVERY targeted PR:
 CI green, CodeQL clean, threads resolved, no conflicts, code simplified, local linters and tests pass, metadata updated.
 If ANY fails, loop back to Phase 2. CRITICAL: CodeQL is SEPARATE from CI — check both independently.
 
-**MERGE PROHIBITION**: FORBIDDEN from merging, auto-merging, enabling auto-merge, or approving any PR.
-
 ## Phase 6: Aggregate Report (Multi-PR Only)
 
 Emit the **Canonical PR Status Summary** as defined in /gh-cli-patterns, titled
@@ -254,7 +245,6 @@ Emit the **Canonical PR Status Summary** as defined in /gh-cli-patterns, titled
 PRs in affected repos (current repo for `all` mode; all repos from Phase 1 discovery
 for `org` mode). Show the target repo as a label next to each merge command (no `--repo` flag; user
 runs from the correct worktree).
-Wait for explicit user merge commands.
 
 ## Workflow
 

--- a/github-workflows/skills/refresh-repo/SKILL.md
+++ b/github-workflows/skills/refresh-repo/SKILL.md
@@ -8,7 +8,6 @@ description: Check PR merge readiness, sync local repo, cleanup stale worktrees;
 # Git Refresh
 
 Check open PR merge-readiness status, sync the local repository, and cleanup stale worktrees.
-**Note**: Does not automatically merge PRs - only reports readiness status for each PR.
 
 > **State warning**: Branch state, remote tracking, and PR status change between
 > invocations. Re-run all git/gh commands from Step 1.
@@ -29,7 +28,7 @@ gh pr list --author @me --state open --json number,title,headRefName
 
 ### 2. Report Merge-Readiness Status
 
-For each open PR, **DO NOT MERGE** - only check and report.
+For each open PR, check and report.
 
 Run the **canonical PR-readiness gate** from /gh-cli-patterns.
 Replace `<OWNER>`, `<REPO>`, `<PR_NUMBER>` per the placeholder legend in that skill.

--- a/github-workflows/skills/ship/SKILL.md
+++ b/github-workflows/skills/ship/SKILL.md
@@ -2,14 +2,14 @@
 name: ship
 description: >-
   Commit, push, create PR(s), and auto-finalize — full automation pipeline.
-  Handles uncommitted changes and recently created PRs. Never merges.
+  Handles uncommitted changes and recently created PRs.
 allowed-tools: Bash(git *), Bash(gh *), Bash(pre-commit *), Bash(npm run lint*), Bash(make lint*), Agent, Read, Grep, Glob, Skill
 ---
 
 # Ship
 
 **Single command to commit, push, create PR(s), and auto-finalize everything.**
-Handles commit, push, PR creation, and `/finalize-pr` in one pipeline. Never merges.
+Handles commit, push, PR creation, and `/finalize-pr` in one pipeline.
 
 > ⛔ **NOT RESUMABLE — run from Step 0 on every `/ship` invocation.**
 > Do not refer to "the PR I just finalized" or "already verified" from
@@ -189,13 +189,6 @@ gh pr view <PR_NUMBER> --json url --jq '.url'
 
 Section 1 lists the PRs targeted by this `/ship` invocation. Section 2 lists all open
 PRs in the current repo (including unrelated ones).
-
-## Safety
-
-- **NEVER merge** — only prepare PRs for human review
-- **NEVER approve** — no auto-approval of PRs
-- Each `/finalize-pr` agent enforces its own merge prohibition
-- This command inherits all safety constraints from `/finalize-pr`
 
 ## Examples
 

--- a/pr-lifecycle/ARCHITECTURE.md
+++ b/pr-lifecycle/ARCHITECTURE.md
@@ -34,11 +34,6 @@ flowchart LR
 When `/ship` is the orchestrator, it suppresses this hook's systemMessage and invokes
 `/finalize-pr` itself with the context brief from Step 1.5.
 
-## Safety
-
-The hook explicitly forbids merging, auto-merging, or approving. It only drives the PR
-toward a mergeable state for human review.
-
 ## Cross-References
 
 - [github-workflows/ARCHITECTURE.md](../github-workflows/ARCHITECTURE.md) — master

--- a/pr-lifecycle/README.md
+++ b/pr-lifecycle/README.md
@@ -20,11 +20,6 @@ The hook monitors Bash tool calls for `gh pr create` commands. When a PR is succ
 created (detected by a GitHub PR URL in the output), it emits a `systemMessage` instructing
 Claude to invoke `/finalize-pr` with the new PR number.
 
-## Safety
-
-The hook explicitly forbids merging, auto-merging, or approving merge of any PR. The
-`/finalize-pr` skill drives the PR to a mergeable state for human review only.
-
 ## Hook Details
 
 | Field | Value |

--- a/pr-lifecycle/scripts/post-pr-create.sh
+++ b/pr-lifecycle/scripts/post-pr-create.sh
@@ -37,6 +37,6 @@ pr_number="${BASH_REMATCH[1]}"
 # not prevent a higher-level orchestrator (e.g., /ship) from continuing its workflow.
 cat <<EOF
 {
-  "systemMessage": "POST-PR AUTOMATION: PR #${pr_number} was just created. If no higher-level workflow (such as /ship) is already handling finalization, you MUST invoke /finalize-pr ${pr_number} before returning to the user. SAFETY: You are FORBIDDEN from merging, auto-merging, or approving merge of any PR. Only get it to a mergeable state for human review."
+  "systemMessage": "POST-PR AUTOMATION: PR #${pr_number} was just created. If no higher-level workflow (such as /ship) is already handling finalization, you MUST invoke /finalize-pr ${pr_number} before returning to the user."
 }
 EOF


### PR DESCRIPTION
## Summary
- Remove the "AI must not merge" / "wait for human to review before merge" prohibition text from pr-lifecycle (README, ARCHITECTURE, post-pr-create.sh systemMessage), github-workflows (finalize-pr, ship, refresh-repo, README), and ai-delegation's auto-maintain skill
- Delete the local (untracked) hookify rule that technically blocked `gh pr merge` until review threads were checked in-session
- Left untouched: github-workflows/ARCHITECTURE.md's mermaid diagram (documents /squash-merge-pr and /rebase-pr as separately-invoked commands, an architecture fact rather than a ban) and docs/LABELS.md's ai:created/ai:ready label system (a different gate for starting work on AI-authored issues, not merging)

## Test plan
- [ ] Confirm CI/lint passes on the modified markdown and shell files
- [ ] Spot-check finalize-pr/SKILL.md and ship/SKILL.md render correctly (no orphaned headings, correct ordered-list numbering)

Generated with Claude Code

https://claude.ai/code/session_01MkPCwTdBuDdkuW38ATan4R