### PR TITLE
docs(project-standards): claude-skill-authoring — two-tier token budget standard (PR1/5)

### DIFF
--- a/.claude-plugin/categories/core.nix
+++ b/.claude-plugin/categories/core.nix
@@ -39,7 +39,7 @@
 
   skills = [
     # jacobpevans project-standards
-    "agentsmd-authoring"
+    "claude-skill-authoring"
     "skills-registry"
     "workspace-standards"
     # jacobpevans code-standards

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -24,7 +24,7 @@ This is a **Claude Code plugins repository** containing production-ready hooks f
 | **pal-health** | SessionStart | — | Warns on session start if PAL MCP had a recent Doppler auth failure |
 | **pr-lifecycle** | PostToolUse | Bash | Automatically triggers `/finalize-pr` after `gh pr create` succeeds |
 | **process-cleanup** | PostToolUse | — | Cleanup orphaned MCP server processes on session exit |
-| **project-standards** | Skill | `/agentsmd-authoring`, `/workspace-standards`, `/skills-registry` | AgentsMD authoring standards, workspace management, and skills/tools registry lookup |
+| **project-standards** | Skill | `/claude-skill-authoring`, `/workspace-standards`, `/skills-registry` | Claude skill authoring standards, workspace management, and skills/tools registry lookup |
 | **session-analytics** | Skill | `/token-breakdown` | Session token analytics via Splunk OTEL telemetry |
 
 ## Multi-Model Delegation

--- a/README.md
+++ b/README.md
@@ -77,7 +77,7 @@ On-demand skill-based plugins that load specific standards as context.
 | **code-standards** | `/code-quality-standards`, `/review-standards` | Code quality, documentation, testing, review guidelines |
 | **git-standards** | `/git-workflow-standards`, `/pr-standards` | Branching, PR creation, issue linking |
 | **infra-standards** | `/infrastructure-standards` | Proxmox, Terraform, Ansible deployment |
-| **project-standards** | `/agentsmd-authoring`, `/workspace-standards`, `/skills-registry`, `/nix-tool-policy` | AgentsMD authoring, workspace, skills registry, Nix tool policy |
+| **project-standards** | `/claude-skill-authoring`, `/workspace-standards`, `/skills-registry`, `/nix-tool-policy` | Claude skill authoring, workspace, skills registry, Nix tool policy |
 
 ### pal-health
 

--- a/project-standards/.claude-plugin/plugin.json
+++ b/project-standards/.claude-plugin/plugin.json
@@ -1,14 +1,14 @@
 {
   "name": "project-standards",
   "version": "4.5.0",
-  "description": "AgentsMD authoring standards, workspace management, and skills/tools registry lookup",
+  "description": "Claude skill authoring standards, workspace management, and skills/tools registry lookup",
   "author": {
     "name": "JacobPEvans"
   },
   "license": "MIT",
   "repository": "https://github.com/JacobPEvans/claude-code-plugins",
   "keywords": [
-    "agentsmd",
+    "claude",
     "authoring",
     "workspace",
     "skills",
@@ -16,7 +16,7 @@
     "standards"
   ],
   "skills": [
-    "./skills/agentsmd-authoring",
+    "./skills/claude-skill-authoring",
     "./skills/workspace-standards",
     "./skills/skills-registry",
     "./skills/nix-tool-policy"

--- a/project-standards/ARCHITECTURE.md
+++ b/project-standards/ARCHITECTURE.md
@@ -1,7 +1,7 @@
 # project-standards — Architecture
 
 Meta-plugin governing the structure and conventions of all other plugins. Provides
-authoring standards for AgentsMD files, workspace conventions, and a registry of all
+authoring standards for Claude skills/agents/rules, workspace conventions, and a registry of all
 available tools and skills.
 
 ## Integration Map
@@ -12,7 +12,7 @@ flowchart TD
     classDef external fill:#f3e5f5,stroke:#6a1b9a,color:#4a148c
 
     subgraph standards["project-standards (this plugin)"]
-        AA["/agentsmd-authoring\nSKILL.md, COMMAND.md, agent\nfrontmatter conventions"]:::ai
+        AA["/claude-skill-authoring\ntoken budgets, progressive\ndisclosure, placement"]:::ai
         WS["/workspace-standards\nCross-project conventions,\nworktree layout, direnv"]:::ai
         SR["/skills-registry\nLookup table for all tools,\nskills, commands, agents"]:::ai
     end
@@ -36,6 +36,6 @@ flowchart TD
 This plugin does not participate in any runtime workflow. It provides reference
 documentation that governs how all other plugins are authored and organized:
 
-- **/agentsmd-authoring** — frontmatter fields, progressive disclosure, naming
+- **/claude-skill-authoring** — token budgets, progressive disclosure, placement, naming
 - **/workspace-standards** — worktree layout, cross-repo conventions, direnv
 - **/skills-registry** — canonical lookup for discovering available capabilities

--- a/project-standards/README.md
+++ b/project-standards/README.md
@@ -1,12 +1,12 @@
 # project-standards
 
-AgentsMD authoring standards, workspace management, and skills/tools registry lookup.
+Claude skill authoring standards, workspace management, and skills/tools registry lookup.
 
 See [ARCHITECTURE.md](ARCHITECTURE.md) for integration diagrams.
 
 ## Skills
 
-- **`/agentsmd-authoring`** - File structure, token targets, two-tier architecture, frontmatter templates
+- **`/claude-skill-authoring`** - Token budgets, progressive disclosure, self-contained rule, component placement
 - **`/workspace-standards`** - Cross-project standards, git workflow, security, cost management
 - **`/skills-registry`** - Lookup table for all available tools, skills, commands, agents, plugins
 - **`/nix-tool-policy`** - Never install tools that Nix dev shells provide; use the dev shell or a temporary nix shell
@@ -20,7 +20,7 @@ claude plugins add jacobpevans-cc-plugins/project-standards
 ## Usage
 
 ```text
-/agentsmd-authoring
+/claude-skill-authoring
 /workspace-standards
 /skills-registry
 ```

--- a/project-standards/skills/agentsmd-authoring/SKILL.md
+++ b/project-standards/skills/agentsmd-authoring/SKILL.md
@@ -1,9 +1,13 @@
 ---
 name: agentsmd-authoring
-description: Use when editing agentsmd files, creating skills/agents/rules, or working in ai-assistant-instructions
+description: Use when authoring or editing skills, agents, rules, or CLAUDE.md/AGENTS.md — token budgets, progressive disclosure, the self-contained-skill rule, the safety-reminder carve-out, and where each component belongs
 ---
 
 # AgentsMD Authoring Standards
+
+**Commands are skills.** A slash command and a skill are the same mechanism — a
+`SKILL.md` (or a legacy flat `commands/*.md`) that you or the model can invoke.
+Author everything new as a skill; flat `commands/*.md` still work but are legacy.
 
 ## File Structure
 
@@ -18,22 +22,58 @@ agentsmd/                     # Single source of truth
 .copilot/, .claude/, .gemini/ # Vendor dirs — symlinks only, no duplicates
 ```
 
-## Token Targets
+## Token Budget
 
-- **Target**: 500 tokens per file
-- **Maximum**: 1,000 tokens per file
-- **CLAUDE.md additions**: bare minimum — link to rules/skills for details
-- **Single-purpose**: each skill/agent/rule does one thing
+Everything is measured in **tokens** — the actual context cost — not lines or
+bytes. Count with the same tool the guard uses: `atc -m sonnet`. The budget
+depends on *when the file loads into context*:
 
-## Two-Tier Architecture
+| Tier | Files | Loads | Target | Max |
+| --- | --- | --- | --- | --- |
+| Always-on | `CLAUDE.md`/`AGENTS.md`, `.claude/rules/*`, plugin `rules/*` | every session | 500 | 1000 |
+| On-demand body | `skills/*/SKILL.md`, `agents/*.md`, `commands/*.md` | when invoked, then persists | 1500 | 3500 |
+| Reference | `skills/*/references/*.md` | only when the body links to it | single-topic | — |
 
-| Tier | Location | Purpose |
+A skill **description** is always loaded (it drives skill selection): keep the
+combined `description` + `when_to_use` within the **1,536-char** listing cap and
+lead with the use case.
+
+**Canonical catalogs and state machines** (e.g. `gh-cli-patterns`, `finalize-pr`)
+may exceed the on-demand max — record an explicit waiver rather than splitting a
+procedure that must stay whole.
+
+## The two rules that override token count
+
+1. **Self-contained execution.** A skill must run correctly and safely when it
+   loads **alone**. Before trimming or moving anything out, ask: *"if only this
+   skill loaded, would it still work?"* If not, the content stays inline. Token
+   count is a flag, never a reason to break this.
+2. **Safety reminders stay inline — even when duplicated.** A "see X" reference
+   is absent when only the referencing skill loads, so keep invocation-local
+   correctness/safety content inline in every skill that acts on it (destructive
+   git ops, merge-readiness gates, "don't act on stale state", least-privilege
+   rules in editing agents). Deduplicate *reference material* (command catalogs,
+   queries, examples, tables) — never decision logic a caller needs before it
+   knows to load the source.
+
+## Progressive disclosure
+
+Keep `SKILL.md` to the essential procedure. Move offloadable reference material
+(long examples, lookup tables, command catalogs, background) into
+`skills/<name>/references/*.md` and link to it from the body — those files cost
+nothing until the body points to them. Offload only what the self-contained rule
+permits.
+
+## Agents vs Skills
+
+| Component | Location | Purpose |
 | --- | --- | --- |
-| Agents | `.claude/agents/` | Task execution — single-responsibility workers |
-| Skills | `agentsmd/skills/` | Canonical patterns — reusable rules/decision trees |
+| Skill | `skills/` | The canonical "right way" — reusable procedure/decision tree |
+| Agent | `agents/` | A single-responsibility worker that *references* skills |
 
-**Agents** reference skills for patterns. **Skills** define the "right way"
-to do something. Agents do NOT duplicate skill logic — they reference it.
+Agents do NOT duplicate skill logic — they reference it. Exception: an agent that
+is itself the actor performing a risky change keeps the relevant safety rule
+inline (self-contained rule).
 
 ## Naming Convention
 
@@ -47,7 +87,7 @@ to do something. Agents do NOT duplicate skill logic — they reference it.
 ```yaml
 ---
 name: skill-name
-description: Pattern description
+description: Lead with the use case; ≤1,536 chars combined with when_to_use
 ---
 ```
 
@@ -65,20 +105,20 @@ allowed-tools: [list of tools]
 
 ## Cross-Referencing
 
-- **In CLAUDE.md**: Use `@path/to/file` to compose content inline.
-  Use markdown links only for conditional "see X if relevant" references.
-- **In agents/skills/rules**: Reference by name
-  (e.g., "the code-standards rule"). Rules in `.claude/rules/` auto-load.
+- **In CLAUDE.md**: Use `@path/to/file` to compose content inline. Use markdown
+  links only for conditional "see X if relevant" references.
+- **In agents/skills/rules**: Reference by name (e.g., "the code-standards
+  rule"). Rules in `.claude/rules/` auto-load.
 
 ## Vendor Config Standard
 
 Vendor directories contain symlinks only. All canonical content lives in
-`agentsmd/`. DRY — never duplicate across vendors.
-
-Rules in `agentsmd/rules/` auto-load every session via `.claude/rules`
-symlink. Keep rules focused and under 1,000 tokens.
+`agentsmd/`. DRY — never duplicate across vendors. Rules in `agentsmd/rules/`
+auto-load every session via the `.claude/rules` symlink; hold them to the
+always-on tier budget above.
 
 ## Related Skills
 
-- **skills-registry** (project-standards) — Use when looking up available tools, skills, commands, agents, or plugins
+- **skills-registry** (project-standards) — Use when looking up available skills, agents, tools, or plugins
 - **workspace-standards** (project-standards) — Use when setting up or managing multi-repo workspaces
+- **code-quality-standards** (code-standards) — DRY and documentation-format rules applied here

--- a/project-standards/skills/claude-skill-authoring/SKILL.md
+++ b/project-standards/skills/claude-skill-authoring/SKILL.md
@@ -1,5 +1,5 @@
 ---
-name: agentsmd-authoring
+name: claude-skill-authoring
 description: Use when authoring or editing skills, agents, rules, or CLAUDE.md/AGENTS.md — token budgets, progressive disclosure, the self-contained-skill rule, the safety-reminder carve-out, and where each component belongs
 ---
 

--- a/project-standards/skills/skills-registry/SKILL.md
+++ b/project-standards/skills/skills-registry/SKILL.md
@@ -35,7 +35,7 @@ description: Use when looking up available tools, skills, commands, agents, or p
 | Code quality | `/code-quality-standards` | `code-standards` | Code rules |
 | Code review | `/review-standards` | `code-standards` | Review focus |
 | Infrastructure | `/infrastructure-standards` | `infra-standards` | IaC standards |
-| AgentsMD authoring | `/agentsmd-authoring` | `project-standards` | File structure |
+| Claude skill authoring | `/claude-skill-authoring` | `project-standards` | Token budgets & placement |
 | Workspace management | `/workspace-standards` | `project-standards` | Multi-repo |
 | This registry | `/skills-registry` | `project-standards` | Tool lookup |
 
@@ -81,5 +81,5 @@ All plugins sourced from `jacobpevans-cc-plugins`.
 
 ## Related Skills
 
-- **agentsmd-authoring** (project-standards) — Use when editing agentsmd files, creating skills/agents/rules, or working in ai-assistant-instructions
+- **claude-skill-authoring** (project-standards) — Use when authoring Claude skills/agents/rules — token budgets, progressive disclosure, placement
 - **workspace-standards** (project-standards) — Use when setting up or managing multi-repo workspaces

--- a/project-standards/skills/workspace-standards/SKILL.md
+++ b/project-standards/skills/workspace-standards/SKILL.md
@@ -44,5 +44,5 @@ Define and monitor monthly budgets per environment.
 
 ## Related Skills
 
-- **agentsmd-authoring** (project-standards) — Use when editing agentsmd files, creating skills/agents/rules, or working in ai-assistant-instructions
+- **claude-skill-authoring** (project-standards) — Use when authoring Claude skills/agents/rules — token budgets, progressive disclosure, placement
 - **skills-registry** (project-standards) — Use when looking up available tools, skills, commands, agents, or plugins


### PR DESCRIPTION
## Summary

**PR1 of 5** in the phased token-optimization + de-duplication pass (plan approved in-session). Text/rename only — establishes the standard every later PR cites; no skill/hook behavior changes.

**1. Rewrites the authoring standard** (`project-standards/skills/.../SKILL.md`):
- Replaces the flat "500 tokens/file" rule with a **tokens-only, tiered budget** keyed to *when a file loads*:
  | Tier | Loads | Target | Max |
  | --- | --- | --- | --- |
  | Always-on (CLAUDE.md/AGENTS.md, rules) | every session | 500 | 1000 |
  | On-demand body (SKILL.md, agents, commands) | when invoked | 1500 | 3500 |
  | Reference (references/*.md) | only when linked | single-topic | — |
- Canonical counter `atc -m sonnet` (matches the content-guards hook).
- Adds the **two rules that override token count**: self-contained execution (a skill must run safely if loaded alone) and safety-reminders-stay-inline (only *reference material* gets centralized).
- Records that **commands are merged into skills** (verified against current docs).

**2. Renames the skill** `agentsmd-authoring` → **`claude-skill-authoring`** (opaque/not-Claude-specific → direct). Directory + frontmatter + every reference updated: plugin.json (path/description/keyword), categories nix list, root README + AGENTS.md catalogs, plugin README/ARCHITECTURE, and the skills-registry + workspace-standards footers.

## Ratify here
Token numbers (500/1000, 1500/3500) are **proposed** — confirm or adjust; PR5 wires them into a `.token-limits.yaml` the guard enforces. `atc` isn't installed on the dev machine, so sizes are word-count estimates pending a real baseline. From measured files, bloated skills land ~2500-2800 est tokens, so a lower on-demand max (~2500) would flag more if you want the budget to bite harder.

## Test plan
- [x] markdownlint clean (7 files); plugin.json valid; zero stale `agentsmd-authoring` refs
- [x] New body ~963 tokens (est) — within the on-demand target it defines
- [ ] Confirm the proposed tier numbers

Generated with Claude Code

https://claude.ai/code/session_01MkPCwTdBuDdkuW38ATan4R