### PR TITLE
chore(content-guards): raise default 24h PR/issue rate limit 25 -> 50

### DIFF
--- a/content-guards/scripts/enforce-issue-limits.py
+++ b/content-guards/scripts/enforce-issue-limits.py
@@ -13,7 +13,7 @@ Hard limits (per-repo):
 Rate limits (24h rolling window), configurable WITHOUT a code change:
   - GH_ACTION_LIMIT_ISSUE / GH_ACTION_LIMIT_PR — read from the environment
     first, then from the target repo owner's GitHub Actions org variable of
-    the same name (settable via Doppler -> GH org variable sync), else 25.
+    the same name (settable via Doppler -> GH org variable sync), else 50.
 
 Exit codes:
   0 = allow the command
@@ -35,7 +35,7 @@ HARD_LIMITS = {"issue": (100, 25), "pr": (15, 15)}
 
 # 24h rolling rate limit default; overridable per resource type via
 # GH_ACTION_LIMIT_{ISSUE|PR} (env, then the repo owner's Actions org variable).
-RATE_LIMIT_24H_DEFAULT = 25
+RATE_LIMIT_24H_DEFAULT = 50
 
 _CMD_RE = re.compile(r"(?:^|\s)gh\s+(issue|pr)\s+(create|edit)(?:\s|$)")
 

--- a/tests/content-guards/enforce-issue-limits/enforce-issue-limits.bats
+++ b/tests/content-guards/enforce-issue-limits/enforce-issue-limits.bats
@@ -121,10 +121,10 @@ run_hook() {
 # TC5: gh issue create - 24h rate limit (exit 2)
 # ---------------------------------------------------------------------------
 
-@test "TC5: gh issue create blocked when 25 issues created in last 24h" {
+@test "TC5: gh issue create blocked when 50 issues created in last 24h" {
   local now
   now="$(utc_now)"
-  export GH_RESPONSE="$(build_json_array '{"number":__N__,"labels":[],"createdAt":"'"$now"'"}' 25)"
+  export GH_RESPONSE="$(build_json_array '{"number":__N__,"labels":[],"createdAt":"'"$now"'"}' 50)"
 
   run_hook '{"tool_input":{"command":"gh issue create --title test"}}'
   [ "$status" -eq 2 ]
@@ -136,12 +136,12 @@ run_hook() {
 # TC6: gh pr create - 24h rate limit (exit 2)
 # ---------------------------------------------------------------------------
 
-@test "TC6: gh pr create blocked when 25 PRs created in last 24h" {
+@test "TC6: gh pr create blocked when 50 PRs created in last 24h" {
   local now
   now="$(utc_now)"
-  # Open PRs under hard limit (14 < 15), but 25 total created in 24h (rate limit)
+  # Open PRs under hard limit (14 < 15), but 50 total created in 24h (rate limit)
   export GH_RESPONSE="$(build_json_array '{"number":__N__,"labels":[],"createdAt":"'"$now"'"}' 14)"
-  export GH_RESPONSE_ALL="$(build_json_array '{"createdAt":"'"$now"'"}' 25)"
+  export GH_RESPONSE_ALL="$(build_json_array '{"createdAt":"'"$now"'"}' 50)"
 
   run_hook '{"tool_input":{"command":"gh pr create --title test"}}'
   [ "$status" -eq 2 ]
@@ -157,7 +157,7 @@ run_hook() {
   local now
   now="$(utc_now)"
   # Even at the rate limit ceiling, edit should pass
-  export GH_RESPONSE="$(build_json_array '{"createdAt":"'"$now"'"}' 25)"
+  export GH_RESPONSE="$(build_json_array '{"createdAt":"'"$now"'"}' 50)"
 
   run_hook '{"tool_input":{"command":"gh pr edit 42 --title new-title"}}'
   [ "$status" -eq 0 ]
@@ -166,7 +166,7 @@ run_hook() {
 @test "TC7b: gh pr edit with --body is always allowed" {
   local now
   now="$(utc_now)"
-  export GH_RESPONSE="$(build_json_array '{"createdAt":"'"$now"'"}' 25)"
+  export GH_RESPONSE="$(build_json_array '{"createdAt":"'"$now"'"}' 50)"
 
   run_hook '{"tool_input":{"command":"gh pr edit 126 --body \"updated description\""}}'
   [ "$status" -eq 0 ]


### PR DESCRIPTION
User-requested bump (clean double, 25 → 50) of the 24h rolling rate-limit fallback default. The designed no-code-change knob (`GH_ACTION_LIMIT_{ISSUE|PR}` env / owner org variable) is untouched and still wins over the default. Docstring updated to match. The installed 4.5.0 cache was patched identically for immediate effect; this PR makes it stick across plugin updates.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HXiX2uJBEn6HNa2brL6iKd