### PR TITLE
feat(ai-delegation): add premium agent orchestration

### DIFF
--- a/.claude-plugin/categories/core.nix
+++ b/.claude-plugin/categories/core.nix
@@ -79,6 +79,7 @@
     # jacobpevans ai-delegation
     "delegate-to-ai"
     "auto-maintain"
+    "premium-agent-orchestration"
   ];
 
   claudeCommands = [

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -57,7 +57,7 @@
     {
       "name": "ai-delegation",
       "source": "./ai-delegation",
-      "description": "Delegate tasks to external AI models and run autonomous maintenance loops",
+      "description": "Delegate tasks to AI models, orchestrate premium-model work, and run autonomous maintenance loops",
       "version": "4.6.0",
       "author": {
         "name": "JacobPEvans"

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -10,7 +10,7 @@ This is a **Claude Code plugins repository** containing production-ready hooks f
 
 | Plugin | Type | Tools/Commands | Purpose |
 |--------|------|--------|------|
-| **ai-delegation** | Skill | `/delegate-to-ai`, `/auto-maintain` | Route tasks to external AI models (Gemini, Ollama, etc.) via PAL MCP |
+| **ai-delegation** | Skill | `/delegate-to-ai`, `/auto-maintain`, `/premium-agent-orchestration` | Route tasks to AI models and preserve premium reasoning while cheaper agents or local/free LLMs handle checkable work |
 | **codeql-resolver** | Command/Skill/Agent | `/resolve-codeql` | Resolve CodeQL security alerts in GitHub Actions workflows |
 | **config-management** | Skill | `/sync-permissions`, `/quick-add-permission` | Manage Claude and Gemini permission configs across repositories |
 | **content-guards** | Pre/PostToolUse | Bash, Write, Edit | Token limits, markdown/README validation, webfetch guard, issue/PR rate limiting, branch limits |
@@ -29,5 +29,6 @@ This is a **Claude Code plugins repository** containing production-ready hooks f
 
 ## Multi-Model Delegation
 
-Use `/delegate-to-ai` to route tasks to external AI models (Gemini, local Ollama, etc.) via PAL MCP.
-Useful for research, code review consensus, and multi-model validation. See the `ai-delegation` plugin.
+Use `/delegate-to-ai` to route tasks to external AI models, local LLMs, or native subagents.
+Use `/premium-agent-orchestration` when a Fable, Opus, or other top-tier model should keep senior judgment while cheaper agents or local/free LLMs handle checkable work.
+Useful for research, code review consensus, multi-model validation, and premium-model cost control. See the `ai-delegation` plugin.

--- a/README.md
+++ b/README.md
@@ -6,11 +6,11 @@ A collection of Claude Code plugins for enhanced development workflows with AI a
 
 ### ai-delegation
 
-Delegate tasks to external AI models and run autonomous maintenance loops.
+Delegate tasks to AI models, orchestrate premium-model work, and run autonomous maintenance loops.
 
 - **Type**: Skill-based plugin
-- **Skills**: `/delegate-to-ai`, `/auto-maintain`
-- **Purpose**: Route tasks to Gemini, local Ollama, or other models via PAL MCP
+- **Skills**: `/delegate-to-ai`, `/auto-maintain`, `/premium-agent-orchestration`
+- **Purpose**: Route tasks to available models and preserve premium reasoning for judgment while cheaper agents or local/free LLMs handle checkable work
 
 ### codeql-resolver
 
@@ -163,7 +163,8 @@ invocation. Skill-based plugins provide slash commands:
 /refresh-repo             # Sync main, check PRs, cleanup worktrees
 /wrap-up                  # Post-merge cleanup + retrospective
 /resolve-codeql           # Fix CodeQL security alerts
-/delegate-to-ai           # Route tasks to external AI models
+/delegate-to-ai           # Route tasks to available AI models
+/premium-agent-orchestration # Preserve premium reasoning and delegate checkable work
 ```
 
 ## Architecture

--- a/ai-delegation/.claude-plugin/plugin.json
+++ b/ai-delegation/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "ai-delegation",
   "version": "4.6.0",
-  "description": "Delegate tasks to external AI models and run autonomous maintenance loops",
+  "description": "Delegate tasks to AI models, orchestrate premium-model work, and run autonomous maintenance loops",
   "author": {
     "name": "JacobPEvans"
   },
@@ -17,6 +17,7 @@
   ],
   "skills": [
     "./skills/delegate-to-ai",
-    "./skills/auto-maintain"
+    "./skills/auto-maintain",
+    "./skills/premium-agent-orchestration"
   ]
 }

--- a/ai-delegation/README.md
+++ b/ai-delegation/README.md
@@ -1,11 +1,12 @@
 # ai-delegation
 
-Claude Code plugin for delegating tasks to external AI models and running autonomous maintenance loops.
+Claude Code plugin for delegating tasks to AI models, orchestrating premium-model work, and running autonomous maintenance loops.
 
 ## Skills
 
 - **`/delegate-to-ai`** - Route a task to the right model (native subagent, Codex, or local MLX) based on task type
 - **`/auto-maintain`** - Autonomous maintenance orchestrator that continuously finds and dispatches work
+- **`/premium-agent-orchestration`** - Preserve Fable, Opus, and other top-tier model reasoning for judgment while delegating checkable work to cheaper agents, local LLMs, or free tiers
 
 ## Installation
 
@@ -18,6 +19,7 @@ claude plugins add jacobpevans-cc-plugins/ai-delegation
 ```text
 /delegate-to-ai
 /auto-maintain
+/premium-agent-orchestration
 ```
 
 ## License

--- a/ai-delegation/skills/premium-agent-orchestration/SKILL.md
+++ b/ai-delegation/skills/premium-agent-orchestration/SKILL.md
@@ -1,0 +1,134 @@
+---
+name: premium-agent-orchestration
+description: This skill should be used when the active agent is Fable 5, Opus, or another expensive top-tier/SOTA model and the work should preserve premium reasoning for intent, architecture, decomposition, tradeoffs, final review, and synthesis while delegating checkable discovery, implementation, verification, logs, tests, and repetitive work to cheaper agents or local/free LLMs.
+---
+
+# Premium Agent Orchestration
+
+Treat the active premium model as the senior decision-maker. Spend premium
+reasoning only where stronger judgment changes the outcome, and route
+checkable labor to the cheapest capable executor.
+
+## Purpose
+
+Use this skill to keep expensive top-tier models focused on judgment instead of
+labor. Preserve premium reasoning for understanding intent, choosing strategy,
+managing risk, resolving ambiguity, reviewing critical outputs, and giving the
+final answer.
+
+Delegate work when the result can be checked from concrete evidence. Prefer the
+lowest-cost executor that can reliably produce that evidence.
+
+## Senior Model Owns
+
+Keep these decisions with the premium model:
+
+- Understand the real user intent.
+- Decide what matters and what is out of scope.
+- Choose the architecture or approach.
+- Break ambiguous work into clear parts.
+- Decide task order and dependencies.
+- Make tradeoffs between speed, quality, risk, and scope.
+- Identify hidden risks.
+- Resolve disagreement between agents.
+- Review important outputs.
+- Decide when the work is good enough.
+- Give the final answer to the user.
+
+## Delegation Tiers
+
+Delegate work whose output can be verified from evidence.
+
+| Tier | Use for | Boundary |
+| --- | --- | --- |
+| Local/free LLM | File discovery, log summaries, simple scans, checklist verification, cheap summaries | Report facts and evidence; avoid product or architecture calls |
+| Haiku-class | Repo discovery, large-file summaries, log inspection, simple checks, edge-case scanning | Report facts, not direction |
+| Sonnet-class | Scoped implementation, tests, medium debugging, local refactors, following existing patterns | Execute the plan; avoid changing architecture or product intent |
+| Opus-class | Complex implementation, deep debugging, cross-module reasoning, risky review, security-sensitive reasoning | Reason deeply, but leave final authority with the premium lead |
+| Premium lead | Intent, architecture, decomposition, tradeoffs, risk, disagreement, final review, synthesis | Own final decisions and user communication |
+
+## Local And Free-Tier First
+
+Before delegating routine labor to paid cloud models, look for local LLMs and
+absolute cheapest free-tier model access available in the current environment.
+
+Use local or free execution first for the lowest-skill tier when the task is
+easy to verify. Good fits include file search summaries, log inspection,
+test-output summaries, checklist verification, mechanical comparisons, and
+other evidence-gathering tasks.
+
+Prefer these routes in order for simple checkable work:
+
+1. Local LLMs already reachable from the environment.
+2. Absolute cheapest free-tier model access already configured for the session.
+3. Cheap small-model agents.
+4. More capable paid/cloud models only when cheaper routes lack context, tool
+   access, reliability, or reasoning quality.
+
+Discover current model availability live. Do not hard-code physical model IDs,
+provider names, or static task-to-model tables. Use capability roles, local
+registry data, or live model listing when available.
+
+## Boundary
+
+Do the work directly only when delegation would cost more than doing the task,
+or when the task requires senior judgment.
+
+Delegate the task when it is mostly searching, reading, editing, testing, or
+verifying.
+
+Keep the task with the premium lead when it involves intent, design, tradeoffs,
+risk, disagreement, or final approval.
+
+## High-Risk Work
+
+Treat these areas as high-risk:
+
+- Auth.
+- Billing.
+- Permissions.
+- Security.
+- Migrations.
+- Data loss.
+- Shared state.
+- Caching.
+- Concurrency.
+- Cross-module behavior.
+- Public APIs.
+- User-visible workflows.
+
+For high-risk work, keep the decision with the premium lead, use an Opus-class
+agent for the hardest technical execution or review, and use cheaper agents or
+local/free models to verify concrete evidence.
+
+## Operating Loop
+
+1. Decide whether the task needs premium judgment.
+2. Define observable success criteria.
+3. Split checkable labor from judgment-heavy decisions.
+4. Route checkable labor to the cheapest capable local, free, or small-model
+   executor.
+5. Use Sonnet-class agents for normal scoped engineering execution.
+6. Use Opus-class agents for difficult delegated technical work or risky review.
+7. Review each agent's evidence.
+8. Make the important decision with the premium lead.
+9. Verify non-trivial work before answering.
+10. Answer the user briefly.
+
+## Final Gate
+
+Before answering, confirm:
+
+- The real request was handled.
+- Premium reasoning was used only where it mattered.
+- Delegated work came with evidence.
+- Non-trivial work was verified.
+- Remaining risk is clear.
+
+Final responses should mention only what was done or decided, what verification
+passed or failed, and any important remaining risk.
+
+## Related Skills
+
+- delegate-to-ai (ai-delegation)
+- auto-maintain (ai-delegation)

--- a/project-standards/skills/skills-registry/SKILL.md
+++ b/project-standards/skills/skills-registry/SKILL.md
@@ -25,6 +25,7 @@ description: Use when looking up available tools, skills, commands, agents, or p
 | Resolve CodeQL alerts | `/resolve-codeql` | `codeql-resolver` | Fix alerts |
 | Autonomous maintenance | `/auto-maintain` | `ai-delegation` | Finds work |
 | Delegate to AI models | `/delegate-to-ai` | `ai-delegation` | External AI |
+| Orchestrate premium agents | `/premium-agent-orchestration` | `ai-delegation` | Preserve senior judgment |
 | Sync permissions | `/sync-permissions` | `config-management` | Merge perms |
 | Add tool permissions | `/quick-add-permission` | `config-management` | Quick allow |
 | Orchestrate infra | `/orchestrate-infra` | `infra-orchestration` | Cross-repo |


### PR DESCRIPTION
## Summary
- Add `/premium-agent-orchestration` to the `ai-delegation` plugin.
- Preserve Fable, Opus, and other top-tier model reasoning for judgment-heavy work.
- Route checkable discovery, implementation, verification, logs, tests, and repetitive work to cheaper agents, local LLMs, or the absolute cheapest free tiers first.

## Changes
- Adds a self-contained premium-model orchestration skill.
- Registers the skill in plugin metadata and the core skill category registry.
- Updates plugin README, root README, marketplace text, AGENTS quick reference, and the skills registry.

## Test Plan
- `jq empty ai-delegation/.claude-plugin/plugin.json .claude-plugin/marketplace.json`
- `check-jsonschema --schemafile schemas/plugin.schema.json ai-delegation/.claude-plugin/plugin.json`
- `agentskills validate ai-delegation/skills/premium-agent-orchestration`
- `agentskills validate project-standards/skills/skills-registry`
- `nix eval --impure --expr '(import ./.claude-plugin/categories.nix).schemaVersion'`
- `./scripts/run-tests.sh ai-delegation`
- CI-equivalent `cclint ai-delegation` and `cclint project-standards` via temporary Go install under Nix
- `git diff --check`

Refs: dryvist/docs#132