### PR TITLE
feat(github-workflows,git-workflows): git-flow-aware PR base and sync targets

### DIFF
--- a/git-standards/skills/git-workflow-standards/SKILL.md
+++ b/git-standards/skills/git-workflow-standards/SKILL.md
@@ -1,13 +1,18 @@
 ---
 name: git-workflow-standards
-description: Use when managing branches, resolving merge conflicts, syncing with main, or working with worktrees
+description: >-
+  Use when managing branches, resolving merge conflicts, syncing with the
+  default branch, or working with worktrees. Covers both trunk repos (main)
+  and git-flow repos (develop) — see gh-cli-patterns (github-workflows) for
+  default-branch detection.
 ---
 
 # Git Workflow Standards
 
 ## Worktree Structure
 
-All development uses dedicated worktrees. Never work directly on main.
+All development uses dedicated worktrees. Never work directly on the default
+branch — `main` on a trunk repo, `develop` on a git-flow repo.
 Create a worktree for the change; remove it when the work is done.
 
 Every branch with commits MUST have an associated PR.
@@ -22,22 +27,24 @@ worktrees with uncommitted changes are NEVER stale. Use `git worktree remove` (n
 
 ## Branch Hygiene
 
-- Sync main daily: `git pull`
-- Long-running branches: rebase from main weekly
-- Before PRs: ensure branch is on latest main
-- Never branch from feature branches — always from main
+- Sync the default branch daily: `git pull`
+- Long-running branches: rebase from the default branch weekly
+- Before PRs: ensure branch is on the latest default branch
+- Never branch from feature branches — always from the default branch fresh
+  (git-flow repos: `git flow feature start` branches from `develop`)
 - Commit messages: conventional-commit prefixes only, no emoji (see `pr-standards`)
 
 | Method | When |
 | --- | --- |
-| `git merge origin/main` | Default — preserves history, safer |
-| `git rebase origin/main` | Only if branch has NOT been pushed yet |
+| `git merge origin/<default>` | Default — preserves history, safer |
+| `git rebase origin/<default>` | Only if branch has NOT been pushed yet |
 
-Sync main workflow:
+Sync workflow (replace `<default>` with the repo's actual default branch — see
+`gh-cli-patterns`, github-workflows):
 
 ```bash
-git fetch origin main && git pull origin main   # in main
-git merge origin/main --no-edit                 # in the feature worktree
+git fetch origin <default> && git pull origin <default>   # in the <default> worktree
+git merge origin/<default> --no-edit                       # in the feature worktree
 ```
 
 ## Merge Conflict Resolution
@@ -71,6 +78,7 @@ contradictions, or security-sensitive code.
 
 ## Related Skills
 
-- **sync-main** (git-workflows) — Syncs main and merges into current or all PR branches
-- **refresh-repo** (git-workflows) — Full repo sync including PR status and worktree cleanup
+- **sync-main** (git-workflows) — Syncs the repo's default branch and merges into current or all PR branches
+- **refresh-repo** (github-workflows) — Full repo sync including PR status and worktree cleanup
+- **gh-cli-patterns** (github-workflows) — Canonical default-branch detection (trunk vs git-flow)
 - **pr-standards** (git-standards) — PR creation guards, issue linking, and review standards

--- a/git-workflows/README.md
+++ b/git-workflows/README.md
@@ -10,7 +10,7 @@ See [ARCHITECTURE.md](ARCHITECTURE.md) for integration diagrams.
 
 ## Skills
 
-- **`/sync-main`** - Update main from remote and merge into current branch (or all open PR branches with `all`)
+- **`/sync-main`** - Update the repo's default branch from remote (main, or develop on git-flow repos) and merge into current or all open PR branches (`all`)
 - **`/wrap-up`** - Post-merge cleanup: refresh repo, quick retrospective, clean gone branches
 - **`/troubleshoot-rebase`** - Diagnose and recover from git rebase failures
 - **`/troubleshoot-precommit`** - Troubleshoot pre-commit hook failures and auto-fixes

--- a/git-workflows/skills/sync-main/SKILL.md
+++ b/git-workflows/skills/sync-main/SKILL.md
@@ -1,12 +1,22 @@
 ---
 name: sync-main
-description: Update main from remote and merge into current or all PR branches
+description: >-
+  Update the repo's default branch from remote and merge it into the current
+  branch, or all open PR branches. Despite the name (kept for continuity),
+  this syncs whatever the repo's default branch actually is — main on trunk
+  repos, develop on git-flow repos — and on git-flow repos also
+  fast-forwards local main from origin/main.
 ---
 
 # Sync Main
 
-Update the local `main` branch from remote and merge it into the current working branch,
+Update the local default branch from remote and merge it into the current working branch,
 or all open PR branches when using the `all` parameter.
+
+The skill keeps the name `sync-main` for continuity, but it syncs the repo's
+actual default branch, not a literal `main`. On a trunk repo that is the same
+thing; on a git-flow repo the default branch is `develop`, and this skill
+treats `develop` as the sync target throughout.
 
 ## Scope Parameter
 
@@ -19,22 +29,47 @@ or all open PR branches when using the `all` parameter.
 
 ## Prerequisites
 
-- You must be in a feature branch worktree (not on main itself)
+- You must be in a feature branch worktree (not on the default branch itself)
 - The current branch should have no uncommitted changes
+
+## Resolve the Default Branch (Both Modes)
+
+```bash
+DEFAULT_BRANCH=$(gh repo view --json defaultBranchRef --jq '.defaultBranchRef.name')
+```
+
+See /gh-cli-patterns (github-workflows) Canonical Default-Branch Detection for
+what `main` vs `develop` implies. Use `<DEFAULT_BRANCH>` everywhere below.
 
 ## Single Branch Mode (Default)
 
 1. **Verify state**: `git branch --show-current`, `git status --porcelain`
-   - STOP if on main or uncommitted changes
-2. **Sync main**: `git fetch --all --prune --force && git pull` (in `main/`)
-3. **Check for updates**: `git fetch origin --force main`
-4. **Report**: Show commits behind with `git log --oneline HEAD..origin/main` (informational only)
-5. **Merge**: `git merge origin/main --no-edit`
+   - STOP if on `<DEFAULT_BRANCH>` or uncommitted changes
+2. **Sync default branch**: `git fetch --all --prune --force && git pull` (in the `<DEFAULT_BRANCH>` worktree)
+3. **Check for updates**: `git fetch origin --force <DEFAULT_BRANCH>`
+4. **Report**: Show commits behind with `git log --oneline HEAD..origin/<DEFAULT_BRANCH>` (informational only)
+5. **Merge**: `git merge origin/<DEFAULT_BRANCH> --no-edit`
    - If already up-to-date: skip to step 7 and report
    - If merge succeeds cleanly: continue to step 6
    - If conflicts occur: **STOP, do not push**. Report conflict status and follow the **Conflict Resolution** section below
 6. **Push (only if merge succeeded cleanly)**: `git push origin $(git branch --show-current)`
-7. **Report**: branch, main SHA, merge status
+7. **Report**: branch, `<DEFAULT_BRANCH>` SHA, merge status
+
+### Git-Flow Extra Step: Fast-Forward Local Main
+
+If `<DEFAULT_BRANCH> == develop` (git-flow repo) and a local `main` worktree
+exists, also fast-forward it from `origin/main` so it never goes silently
+stale between promotions:
+
+```bash
+git -C <path-to-main-worktree> fetch origin main
+git -C <path-to-main-worktree> merge --ff-only origin/main
+```
+
+Resolve `<path-to-main-worktree>` from `git worktree list --porcelain`,
+matching the `branch refs/heads/main` entry. If no local `main` worktree
+exists, skip this step — there is nothing to fast-forward. Never push here;
+`main` on a git-flow repo only moves via `/promote-release` (github-workflows).
 
 ## All Branches Mode (Orchestrator)
 
@@ -43,12 +78,13 @@ Report sync status for all open PR branches.
 ### Steps
 
 1. **Get repo**: `gh repo view --json nameWithOwner`
-2. **Update main**: CRITICAL - must happen first
+2. **Update default branch**: CRITICAL - must happen first (and its git-flow extra step above)
 3. **List open PRs**: `gh pr list --state open --json number,headRefName,title`
-4. **Check each PR**: Launch subagents in parallel (invoke `superpowers:dispatching-parallel-agents`). Each checks if behind main. Do NOT merge or push.
-5. **Report**: repo, main SHA, merge-readiness for each PR (current/behind/conflict)
+4. **Check each PR**: Launch subagents in parallel (invoke `superpowers:dispatching-parallel-agents`).
+   Each checks if behind `<DEFAULT_BRANCH>`. Do NOT merge or push.
+5. **Report**: repo, `<DEFAULT_BRANCH>` SHA, merge-readiness for each PR (current/behind/conflict)
 6. **Sync conflict-free branches**: For each branch classified as `behind` (not `conflict`) in step 5,
-   merge `origin/main` using `git merge origin/main --no-edit`. Branches already classified as `conflict`
+   merge `origin/<DEFAULT_BRANCH>` using `git merge origin/<DEFAULT_BRANCH> --no-edit`. Branches already classified as `conflict`
    in step 5 are skipped entirely — no merge is attempted on them, so no `git merge --abort` is needed.
    No confirmation required.
 7. **Report conflicting branches**: Branches skipped due to pre-identified conflicts are reported for manual resolution
@@ -66,5 +102,7 @@ Read files, understand both versions, combine intelligently, stage resolved file
 ## Related Skills
 
 - **refresh-repo** (github-workflows) — Full repo sync including PR status and worktree cleanup
-- **rebase-pr** (github-workflows) — Rebase-merge workflow that builds on a synced main
+- **rebase-pr** (github-workflows) — Rebase-merge workflow that builds on a synced base branch
+- **promote-release** (github-workflows) — Moves develop to main on git-flow repos; the fast-forward step here only reads main, never pushes it
+- **gh-cli-patterns** (github-workflows) — Canonical default-branch detection (trunk vs git-flow)
 - **git-workflow-standards** (git-standards) — Branch hygiene and sync conventions

--- a/git-workflows/skills/troubleshoot-rebase/SKILL.md
+++ b/git-workflows/skills/troubleshoot-rebase/SKILL.md
@@ -11,19 +11,32 @@ Diagnose and recover from rebase failures. Invoke when standard rebase error han
 
 Check: `pwd`, `git status`, `git branch --show-current`, `git worktree list`, `gh pr view`.
 
+Resolve the repo's default branch before any rebase — it is the correct rebase
+target, not necessarily `main`:
+
+```bash
+DEFAULT_BRANCH=$(gh repo view --json defaultBranchRef --jq '.defaultBranchRef.name')
+```
+
+`main` on a git-flow repo (default branch `develop`, see /gh-cli-patterns
+Canonical Default-Branch Detection in github-workflows) is never a rebase
+target — it takes merge commits only. Feature branches there rebase onto
+`develop`, and only a `hotfix/*` branch legitimately rebases onto `main`.
+
 ## Error: Push Rejected (Non-Fast-Forward)
 
 Branches have diverged. First, confirm your current branch: `git branch --show-current`.
 
 - If this is a **feature branch** (for example `feature/foo`) and the push was rejected:
-  - Rebase onto the latest main: `git fetch origin --force && git rebase origin/main`
+  - Rebase onto the latest default branch: `git fetch origin --force && git rebase origin/<DEFAULT_BRANCH>`
   - Then push your feature branch: `git push --force-with-lease origin HEAD`
 
-- If you are on **main** and are behind `origin/main`, do **not** rebase main:
-  - Update main: `git fetch origin --force && git reset --hard origin/main`
-  - Then retry your original operation (for example, rebase your feature branch onto main and push the feature branch).
+- If you are on `<DEFAULT_BRANCH>` and are behind `origin/<DEFAULT_BRANCH>`, do
+  **not** rebase it:
+  - Update it: `git fetch origin --force && git reset --hard origin/<DEFAULT_BRANCH>`
+  - Then retry your original operation (for example, rebase your feature branch onto `<DEFAULT_BRANCH>` and push the feature branch).
 
-If the rebase fails because `origin/main` moved again, repeat: fetch, rebase your feature branch, then push with `--force-with-lease`.
+If the rebase fails because `origin/<DEFAULT_BRANCH>` moved again, repeat: fetch, rebase your feature branch, then push with `--force-with-lease`.
 
 ## Error: Repository Rule Violations
 
@@ -31,7 +44,7 @@ GH013 error about PR/status checks. This is NOT a block if commits are from appr
 
 **Causes**: CI not passing, reviews not approved, merge conflict.
 
-**Fix order**: Rebase feature -> push (triggers CI) -> wait for checks -> merge to main -> push.
+**Fix order**: Rebase feature -> push (triggers CI) -> wait for checks -> merge to `<DEFAULT_BRANCH>` -> push.
 
 Check: `gh pr view <branch> --json checks,reviews,statusCheckRollup`
 
@@ -47,7 +60,8 @@ Resolve: edit files, `git add <file>`, then `git rebase --continue` (or `--abort
 
 ## Error: Fast-Forward Merge Failed
 
-Main was updated between rebase and merge. Run `git fetch origin --force && git reset --hard origin/main`, then retry.
+The default branch was updated between rebase and merge. Run
+`git fetch origin --force && git reset --hard origin/<DEFAULT_BRANCH>`, then retry.
 
 ## Error: Feature Branch Push Failed
 
@@ -61,7 +75,7 @@ Fix: `git push --force-with-lease origin <branch>`
 
 Before retrying:
 
-- Main synced: `git diff origin/main --stat` (should be empty)
+- Default branch synced: `git diff origin/<DEFAULT_BRANCH> --stat` (should be empty)
 - Branch clean: `git status`
 - No rebase in progress: check `.git/rebase-{merge,apply}` doesn't exist
 - PR state: `gh pr view <branch> --json state`

--- a/git-workflows/skills/troubleshoot-worktree/SKILL.md
+++ b/git-workflows/skills/troubleshoot-worktree/SKILL.md
@@ -36,6 +36,10 @@ Means TWO things named `origin/main`:
 
 **Fix**: `git branch -D origin/main` then verify only 1 line remains with `git show-ref origin/main`.
 
+The same ambiguity can occur for any branch name, not just `main` — on a
+git-flow repo (default branch `develop`) watch for `origin/develop` too.
+Substitute the branch name in the diagnose/fix commands above.
+
 ## Common Errors
 
 ### Branch Not Found

--- a/git-workflows/skills/wrap-up/SKILL.md
+++ b/git-workflows/skills/wrap-up/SKILL.md
@@ -106,7 +106,7 @@ all prior steps finish. Provide a summary of actions taken.
 Invoke `/refresh-repo` to:
 
 - Check merge-readiness of any remaining open PRs
-- Sync local main with remote
+- Sync the local default branch with remote (main on trunk repos, develop on git-flow repos)
 - Clean up stale worktrees (merged PRs, `[gone]` remote branches)
 - Report repository state
 
@@ -316,8 +316,10 @@ Sequence:
    `gh pr view <PR_NUMBER> --repo <owner>/<repo> --json headRefName --jq '.headRefName'`.
 2. Close the PR and delete the remote branch in one call:
    `gh pr close <PR_NUMBER> --repo <owner>/<repo> --comment "<reason>" --delete-branch`.
-3. If the current worktree IS the captured branch's, `git switch main`
-   first so step 4 can remove it.
+3. If the current worktree IS the captured branch's, switch to the repo's
+   default branch first (`gh repo view --json defaultBranchRef --jq
+   '.defaultBranchRef.name'`, then `git switch <that branch>`) so step 4 can
+   remove it.
 4. Find the worktree path via `git worktree list` matching the captured
    branch, then `git worktree remove <path>` if present, and
    `git branch -D <branch>`.

--- a/github-workflows/.claude-plugin/plugin.json
+++ b/github-workflows/.claude-plugin/plugin.json
@@ -22,6 +22,7 @@
     "./skills/ship",
     "./skills/squash-merge-pr",
     "./skills/rebase-pr",
+    "./skills/promote-release",
     "./skills/refresh-repo",
     "./skills/gh-cli-patterns",
     "./skills/shape-issues",

--- a/github-workflows/ARCHITECTURE.md
+++ b/github-workflows/ARCHITECTURE.md
@@ -25,9 +25,12 @@ graph LR
 ## 1. Skill Dependency Map
 
 All skills and their cross-plugin dependencies. `/refresh-repo`, `/rebase-pr`,
-`/squash-merge-pr`, and `/gh-cli-patterns` are local to this plugin (no cross-plugin
-hop) — `/squash-merge-pr` and `/rebase-pr` both consume the canonical PR-readiness
-gate from `/gh-cli-patterns` directly.
+`/squash-merge-pr`, `/promote-release`, and `/gh-cli-patterns` are local to this
+plugin (no cross-plugin hop) — `/squash-merge-pr`, `/rebase-pr`, and
+`/promote-release` all consume the canonical PR-readiness gate and the
+default-branch detection from `/gh-cli-patterns` directly. On a git-flow repo,
+`/squash-merge-pr` and `/rebase-pr` both refuse a `main`-targeting PR and point
+to `/promote-release` instead.
 
 ```mermaid
 flowchart TD
@@ -36,6 +39,7 @@ flowchart TD
     RPT["/resolve-pr-threads"]:::ai
     SMP["/squash-merge-pr"]:::ai
     RBP["/rebase-pr"]:::ai
+    PRR["/promote-release"]:::ai
     RFR["/refresh-repo"]:::ai
     GCP["/gh-cli-patterns"]:::ai
     TAR["/trigger-ai-reviews"]:::ai
@@ -59,10 +63,15 @@ flowchart TD
 
     RPT -->|"Step 3"| RCR
 
+    SMP -->|"refuses, points to (git-flow + base=main)"| PRR
+    RBP -->|"refuses, points to (git-flow + base=main)"| PRR
+    PRR -->|"drives PR to mergeable"| FPR
+
     FPR -.->|"reference"| GCP
     SHIP -.->|"reference"| GCP
     SMP -.->|"reference"| GCP
     RBP -.->|"reference"| GCP
+    PRR -.->|"reference"| GCP
     RFR -.->|"reference"| GCP
     RPT -.->|"reference"| GCP
 
@@ -130,12 +139,13 @@ flowchart TD
 
     subgraph MERGE ["AI — On Human Command (/squash-merge-pr)"]
         direction TB
+        M0["Step 0: refuse if base=main\non a git-flow repo\n(see /promote-release)"]:::ai
         M1["Validate readiness\n(/gh-cli-patterns PR-readiness gate)"]:::ai
         M2["Generate squash commit"]:::ai
         M3["gh pr merge --squash\n--delete-branch"]:::ai
-        M4["git switch main && git pull"]:::ai
+        M4["git switch base branch && git pull"]:::ai
 
-        M1 --> M2 --> M3 --> M4
+        M0 --> M1 --> M2 --> M3 --> M4
     end
 
     subgraph CLEANUP ["AI — On Human Command (/wrap-up from git-workflows)"]

--- a/github-workflows/README.md
+++ b/github-workflows/README.md
@@ -9,10 +9,11 @@ See [ARCHITECTURE.md](ARCHITECTURE.md) for integration diagrams and the master s
 - **`/ship`** - Full automation: commit, push, create PR(s), and auto-finalize in one command.
 - **`/finalize-pr`** - Finalize PRs for merge: single PR, all repo PRs (`all`), or all org PRs (`org`). Includes bot-authored PRs in all modes.
 - **`/refresh-repo`** - Check PR merge-readiness, sync local repo, and cleanup stale worktrees
-- **`/rebase-pr`** - Merge a PR using local git rebase + signed commits + push to main
-- **`/squash-merge-pr`** - Validate PR readiness and squash merge into main (errors if not ready)
+- **`/rebase-pr`** - Merge a PR using local git rebase + signed commits + a direct push to its base branch (main on trunk repos, develop on git-flow repos)
+- **`/squash-merge-pr`** - Validate PR readiness and squash merge into its base branch (errors if not ready); refuses on git-flow repos when the base is main
+- **`/promote-release`** - Merge-commit a develop → main promotion PR on a git-flow repo; release-please takes over from there
 - **`/resolve-pr-threads`** - Orchestrate resolution of PR review threads (requires superpowers plugin)
-- **`/gh-cli-patterns`** - Canonical reference for gh CLI command shapes used by other skills in this plugin
+- **`/gh-cli-patterns`** - Canonical reference for gh CLI command shapes used by other skills in this plugin, including trunk-vs-git-flow default-branch detection
 - **`/shape-issues`** - Shape raw ideas into actionable GitHub Issues using Shape Up methodology
 - **`/trigger-ai-reviews`** - Trigger Claude, Gemini, and Copilot reviews on a PR
 - **`/shared-workflow-org-refs`** - Literal current-owner `uses:` references for reusable workflows; shared-CI homes under dryvist
@@ -35,6 +36,7 @@ claude plugins add jacobpevans-cc-plugins/github-workflows
 /rebase-pr                # Rebase-merge current branch
 /rebase-pr 42             # Rebase-merge specific PR by number
 /squash-merge-pr          # Validate and squash merge
+/promote-release          # Merge-commit develop into main (git-flow repos)
 /resolve-pr-threads       # Batch resolve review threads
 /shape-issues             # Shape ideas into GitHub issues
 /trigger-ai-reviews       # Trigger Claude, Gemini, Copilot reviews

--- a/github-workflows/skills/finalize-pr/SKILL.md
+++ b/github-workflows/skills/finalize-pr/SKILL.md
@@ -111,8 +111,10 @@ After completion, validate locally.
 #### Merge Conflicts
 
 Check if the PR has git conflicts (`mergeable` field). **`mergeable: MERGEABLE` means no git
-conflicts only** — it does NOT mean the PR is fully ready to merge. **If conflicts**: Fetch main,
-attempt merge, report unresolvable conflicts for user. After resolution, validate locally. Full
+conflicts only** — it does NOT mean the PR is fully ready to merge. **If conflicts**: Fetch the
+PR's base branch (`gh pr view <PR_NUMBER> --json baseRefName --jq '.baseRefName'` — `develop` on
+git-flow repos, `main` on trunk repos or promotion PRs), attempt merge, report unresolvable
+conflicts for user. After resolution, validate locally. Full
 readiness verification (including `mergeStateStatus`, CI, CodeQL, review decision, threads) happens
 in Phase 3.
 
@@ -197,7 +199,7 @@ Steps 4.1 and 4.2 run sequentially within the agent. Step 4.3 runs after both.
 
 ### 4.1 Update PR Title and Description
 
-1. Summarize branch history and diff stats against main; read current PR title and body.
+1. Summarize branch history and diff stats against the PR's base branch; read current PR title and body.
 2. Generate updated title (conventional commit format, <70 chars) and description with sections:
    **Summary**, **Changes**, **Test Plan**.
 

--- a/github-workflows/skills/gh-cli-patterns/SKILL.md
+++ b/github-workflows/skills/gh-cli-patterns/SKILL.md
@@ -2,10 +2,11 @@
 name: gh-cli-patterns
 description: >-
   Canonical reference for all gh CLI command shapes used by skills in this
-  plugin. Defines the placeholder convention, allowed --json fields, GraphQL
-  fallback rules, -f/-F/--raw-field flag semantics, the PR-readiness gate,
-  code-scanning alert query, review-thread fetch/count/resolve mutations, and
-  heredoc bodies. Prevents Unknown JSON field errors and divergent query shapes.
+  plugin. Defines the placeholder convention, default-branch (trunk vs
+  git-flow) detection, allowed --json fields, GraphQL fallback rules,
+  -f/-F/--raw-field flag semantics, the PR-readiness gate, code-scanning
+  alert query, review-thread fetch/count/resolve mutations, and heredoc
+  bodies. Prevents Unknown JSON field errors and divergent query shapes.
 ---
 
 # gh CLI Canonical Patterns — github-workflows
@@ -22,12 +23,37 @@ Two visually distinct notations — never mix them up:
 Standard replacements:
 
 ```text
-<OWNER>       → $(gh repo view --json owner --jq '.owner.login')
-<REPO>        → $(gh repo view --json name  --jq '.name')
-<PR_NUMBER>   → $(gh pr view  --json number --jq '.number')  (integer)
-<THREAD_ID>   → PRRT_* node ID from the fetch-threads query (string)
-<DATABASE_ID> → numeric comment ID from the fetch-threads query
+<OWNER>          → $(gh repo view --json owner --jq '.owner.login')
+<REPO>           → $(gh repo view --json name  --jq '.name')
+<PR_NUMBER>      → $(gh pr view  --json number --jq '.number')  (integer)
+<THREAD_ID>      → PRRT_* node ID from the fetch-threads query (string)
+<DATABASE_ID>    → numeric comment ID from the fetch-threads query
+<DEFAULT_BRANCH> → see Canonical Default-Branch Detection below
 ```
+
+## Canonical Default-Branch Detection
+
+Repos in this org run one of two branch models. Detect which one before
+using any literal `main` in a PR base, sync target, or merge command:
+
+```bash
+gh repo view --json defaultBranchRef --jq '.defaultBranchRef.name'
+# or, without gh: git remote show origin | grep 'HEAD branch'
+```
+
+| `<DEFAULT_BRANCH>` | Model | What it means for skills in this plugin |
+|---|---|---|
+| `main` | Trunk | `main` is both the default branch and production. Existing squash-to-main behavior applies unchanged. |
+| `develop` | git-flow (see [git-flow rule](https://github.com/dryvist/ai-assistant-instructions/blob/main/agentsmd/rules/git-flow.md)) | `develop` is the default integration branch — feature PRs target it, squash-merge is the default. `main` is production only: **merge commits only**, no direct pushes, every merge triggers release-please. |
+
+**Never infer the model from the current local branch name** — always read
+`defaultBranchRef` (or `origin/HEAD`) fresh, since it can differ per repo and
+per invocation.
+
+A PR's own base branch (`gh pr view --json baseRefName --jq '.baseRefName'`)
+can still be `main` on a git-flow repo — that is a promotion PR (`develop` →
+`main`), not a feature PR, and it is merge-commit-only regardless of what
+this section's detection returns. See `/promote-release`.
 
 ## `gh pr view --json` — REST-Only
 
@@ -240,7 +266,7 @@ Append after the URL, separated by ` | `. Omit when no issues exist ("Ready for 
 | `CI pending` | `statusCheckRollup.state != SUCCESS` | `mergeStateStatus == UNKNOWN`/`UNSTABLE` |
 | `CI failed` | CI checks terminal failure | `mergeStateStatus == BLOCKED` (when other fields clean) |
 | `Draft` | `isDraft == true` | `isDraft == true` |
-| `Behind main` | `mergeStateStatus == BEHIND` | `mergeStateStatus == BEHIND` |
+| `Behind {default}` | `mergeStateStatus == BEHIND` | `mergeStateStatus == BEHIND` |
 
 ### Data queries
 

--- a/github-workflows/skills/promote-release/SKILL.md
+++ b/github-workflows/skills/promote-release/SKILL.md
@@ -1,0 +1,115 @@
+---
+name: promote-release
+description: >-
+  Open and merge a develop -> main promotion PR on a git-flow repo. Merge
+  commit only, never squash or rebase — main accepts merge commits only.
+  Every merge to main triggers release-please, which takes over tagging and
+  release notes from there. Refuses on trunk repos (default branch main) —
+  use /squash-merge-pr instead.
+---
+
+# Promote Release
+
+Promotes `develop` to `main` on a git-flow repo: opens (or reuses) a
+`develop` → `main` PR, waits for it to go green, then merges it with a merge
+commit. This is the **only** sanctioned way to move code into `main` on a
+git-flow repo outside a `hotfix/*` PR.
+
+> **State warning**: PR status, CI, and branch state change between
+> invocations. Re-run every git/gh command from Step 0.
+
+## Critical Rules
+
+- **Merge commit only.** Never `--squash`, never `--rebase`. `main`'s ruleset
+  bans both — see /gh-cli-patterns Canonical Default-Branch Detection.
+- This skill does **not** run on trunk repos. Step 0 refuses immediately if
+  the repo's default branch is `main`.
+- Never invent a version number or write CHANGELOG entries yourself —
+  release-please owns both once this PR lands on `main`.
+- `release/*` stabilization branches are out of scope here — use this skill
+  only for the ordinary `develop` → `main` promotion.
+
+## Step 0: Confirm Git-Flow Repo
+
+```bash
+DEFAULT_BRANCH=$(gh repo view --json defaultBranchRef --jq '.defaultBranchRef.name')
+```
+
+If `DEFAULT_BRANCH != develop`, **abort**:
+
+> "This repo's default branch is `{DEFAULT_BRANCH}`, not `develop` — it is not
+> on the git-flow model. There is no develop → main promotion step here; use
+> `/squash-merge-pr` for ordinary PRs into `{DEFAULT_BRANCH}`."
+
+## Step 1: Sync Develop
+
+```bash
+git fetch origin --force develop main
+git log --oneline origin/main..origin/develop   # commits this promotion will carry
+```
+
+If the list is empty, **stop** and report: "`develop` has no commits ahead of
+`main` — nothing to promote."
+
+## Step 2: Find Or Create the Promotion PR
+
+```bash
+gh pr list --base main --head develop --state open --json number,url
+```
+
+**If one exists**: use it for the remaining steps.
+
+**If none exists**, create it:
+
+```bash
+gh pr create --base main --head develop --title "chore: promote develop to main" --body "$(cat <<'EOF'
+## Summary
+Promotes the current state of `develop` to `main`.
+
+## Notes
+- Merge commit only — `main`'s ruleset bans squash and rebase.
+- Merging this PR triggers release-please on `main`, which opens its own
+  release PR (version bump + CHANGELOG) automatically. This PR does not
+  touch versioning itself.
+EOF
+)"
+```
+
+## Step 3: Wait For CI
+
+Run the **canonical PR-readiness gate** from /gh-cli-patterns against the
+promotion PR's number. Replace `<OWNER>`, `<REPO>`, `<PR_NUMBER>` per the
+placeholder convention in that skill.
+
+If blocked (CI red, conflicts, unresolved threads), invoke `/finalize-pr
+<PR_NUMBER>` — it works the same regardless of base branch — then re-run the
+gate. Do not proceed until `mergeStateStatus` is `CLEAN` or `HAS_HOOKS`.
+
+## Step 4: Merge Commit Into Main
+
+```bash
+gh pr merge <PR_NUMBER> --merge --subject "chore: promote develop to main"
+```
+
+**Never** add `--squash` or `--rebase` to this command — both are banned by
+`main`'s ruleset on a git-flow repo and the merge will be rejected (or, worse,
+silently strip the multi-commit history the promotion exists to preserve).
+
+## Step 5: Report
+
+```bash
+gh pr view <PR_NUMBER> --json state,mergedAt --jq '{state, mergedAt}'   # expect: MERGED
+```
+
+Report the merge and note that release-please now owns the next step: it
+watches `main` and opens its own release PR (version bump, CHANGELOG,
+eventual tag) with no further action needed here. Do not create a release PR
+or tag manually.
+
+## Related Skills
+
+- squash-merge-pr (github-workflows) — the feature-PR-into-develop path; refuses and
+  points here when a PR targets main on a git-flow repo
+- finalize-pr (github-workflows) — drives the promotion PR to mergeable state, same as any other PR
+- rebase-pr (github-workflows) — refuses and points here when its target is main on a git-flow repo
+- gh-cli-patterns (github-workflows) — canonical gh CLI command shapes, placeholder convention, PR-readiness gate, default-branch detection

--- a/github-workflows/skills/rebase-pr/SKILL.md
+++ b/github-workflows/skills/rebase-pr/SKILL.md
@@ -1,14 +1,23 @@
 ---
 name: rebase-pr
-description: Local rebase-merge workflow for pull requests with signed commits
+description: >-
+  Local rebase-merge workflow for pull requests with signed commits, pushed
+  directly to the PR's base branch. Refuses on git-flow repos when the base
+  is main — direct pushes to main are banned there; use /promote-release.
 ---
 
 # rebase-pr
 
-Merge a PR using local `git rebase` + signed commits + `git push origin main`.
+Merge a PR using local `git rebase` + signed commits + a direct push to the
+PR's base branch.
 
 `gh pr merge --rebase` cannot sign commits. Local rebase with `commit.gpgsign=true`
-signs every rebased commit. Pushing main directly auto-closes the PR.
+signs every rebased commit. Pushing the base branch directly auto-closes the PR.
+
+This only works where direct pushes to the base branch are allowed: trunk
+repos' `main`, or a git-flow repo's `develop`. Git-flow's `main` accepts
+merge commits only and never direct pushes — Step 0 refuses before any of
+this runs.
 
 ## Dispatch
 
@@ -19,7 +28,7 @@ signs every rebased commit. Pushing main directly auto-closes the PR.
 -->
 
 **MANDATORY FIRST STEP**: Spawn a Haiku subagent using the Agent tool with
-`mode: "bypassPermissions"`. Pass all content starting from **Prerequisite: Validate Rulesets**
+`mode: "bypassPermissions"`. Pass all content starting from **Prerequisite: Validate Base Branch**
 through end-of-document as the agent prompt; include the current branch name and PR number.
 Do not execute any steps yourself — the subagent runs the complete workflow autonomously with
 all permissions auto-accepted.
@@ -28,6 +37,26 @@ If the Haiku subagent cannot be spawned, becomes unavailable, or encounters an u
 error while running this workflow, clearly report the failure to the user and ask whether to
 (a) retry spawning the subagent or (b) proceed manually by following the remaining steps of
 this document together step-by-step.
+
+## Prerequisite: Validate Base Branch
+
+Resolve the PR's base branch and the repo's default branch. Replace `<PR_NUMBER>` before running:
+
+```bash
+BASE_BRANCH=$(gh pr view <PR_NUMBER> --json baseRefName --jq '.baseRefName')
+DEFAULT_BRANCH=$(gh repo view --json defaultBranchRef --jq '.defaultBranchRef.name')
+```
+
+If `BASE_BRANCH == main` AND `DEFAULT_BRANCH == develop` (repo is on git-flow — see
+/gh-cli-patterns Canonical Default-Branch Detection), **ABORT**:
+
+> "This is a `develop` → `main` promotion PR on a git-flow repo. Direct pushes to
+> `main` are banned there — `main` accepts merge commits only, with no exceptions.
+> Run `/promote-release` instead."
+
+Otherwise continue — `BASE_BRANCH` is either a trunk repo's `main` or a git-flow
+repo's `develop`, both of which allow this workflow's direct push. Use
+`<BASE_BRANCH>` in every step below.
 
 ## Prerequisite: Validate Rulesets
 
@@ -42,11 +71,11 @@ gh api repos/<OWNER>/<REPO>/rulesets \
 
 | Rule type | Message |
 |-----------|---------|
-| `non_fast_forward` | "Remove from all-branches ruleset. Feature branches need force-push after rebase. Keep on main-only." |
-| `required_linear_history` | "Remove from all-branches ruleset. Keep on main-only." |
-| `pull_request` | "Remove from all-branches ruleset. Keep on main-only." |
-| `required_status_checks` | "Remove from all-branches ruleset. Keep on main-only." |
-| `code_scanning` | "Remove from all-branches ruleset. Keep on main-only." |
+| `non_fast_forward` | "Remove from all-branches ruleset. Feature branches need force-push after rebase. Keep restricted to the base branch only." |
+| `required_linear_history` | "Remove from all-branches ruleset. Keep restricted to the base branch only." |
+| `pull_request` | "Remove from all-branches ruleset. Keep restricted to the base branch only." |
+| `required_status_checks` | "Remove from all-branches ruleset. Keep restricted to the base branch only." |
+| `code_scanning` | "Remove from all-branches ruleset. Keep restricted to the base branch only." |
 
 Only `required_signatures` belongs on all-branches.
 
@@ -69,11 +98,13 @@ that skill.
 | All `reviewThreads.isResolved` | `true` | "Unresolved review threads — run `/finalize-pr` to fix" |
 | `reviewThreads.pageInfo.hasNextPage` | `false` | ">100 threads — paginate and re-verify" |
 
-## Step 2: Sync Main
+## Step 2: Sync Base Branch
+
+Replace `<BASE_BRANCH>` (from the Prerequisite) before running:
 
 ```bash
-git fetch origin --force main
-git pull origin main
+git fetch origin --force <BASE_BRANCH>
+git pull origin <BASE_BRANCH>
 ```
 
 ## Step 3: Fetch Branch, Create Worktree, Rebase
@@ -86,11 +117,11 @@ git fetch origin --force {branch}
 git branch {branch} origin/{branch}
 ```
 
-Work in the PR branch's worktree and rebase:
+Work in the PR branch's worktree and rebase. Replace `<BASE_BRANCH>` before running:
 
 ```bash
-git rebase origin/main
-git log --oneline origin/main..HEAD   # verify commits are ahead
+git rebase origin/<BASE_BRANCH>
+git log --oneline origin/<BASE_BRANCH>..HEAD   # verify commits are ahead
 ```
 
 ## Step 4: Force-Push and Wait for CI
@@ -111,27 +142,32 @@ git branch --set-upstream-to=origin/{branch} {branch}
 git push --force-with-lease origin {branch}
 ```
 
-## Step 5: Fast-Forward Merge to Main
+## Step 5: Fast-Forward Merge to Base Branch
+
+Replace `<BASE_BRANCH>` before running (`cd` into that branch's own worktree, not
+necessarily a directory literally named `main`):
 
 ```bash
-cd ../main
-git merge-base --is-ancestor origin/main {branch}  # verify FF is possible; exit 0 = yes
+cd ../<BASE_BRANCH>
+git merge-base --is-ancestor origin/<BASE_BRANCH> {branch}  # verify FF is possible; exit 0 = yes
 git merge --ff-only {branch}
 ```
 
-If `merge-base --is-ancestor` exits non-zero, main moved since rebase — go back to Step 2.
+If `merge-base --is-ancestor` exits non-zero, the base branch moved since rebase — go back to Step 2.
 
-## Step 6: Push Main
+## Step 6: Push Base Branch
+
+Replace `<BASE_BRANCH>` before running:
 
 ```bash
-git push origin main
+git push origin <BASE_BRANCH>
 ```
 
-If rejected with "Code scanning waiting". Replace `<PR_NUMBER>` before running:
+If rejected with "Code scanning waiting". Replace `<PR_NUMBER>` and `<BASE_BRANCH>` before running:
 
 ```bash
 gh pr checks <PR_NUMBER> --watch --interval 15
-git push origin main   # retry after checks pass
+git push origin <BASE_BRANCH>   # retry after checks pass
 ```
 
 Verify merged. Replace `<PR_NUMBER>` before running:
@@ -152,12 +188,14 @@ git worktree prune
 ## Never Do This
 
 - **NEVER** use `gh pr merge` — GitHub cannot sign rebase commits
-- **NEVER** `git push --force origin main` — only force-push feature branches
+- **NEVER** `git push --force origin <BASE_BRANCH>` — only force-push feature branches
 - **NEVER** create a local branch from `FETCH_HEAD` — use `origin/{branch}`
-- **NEVER** push to main before CI passes on the rebased branch
+- **NEVER** push to the base branch before CI passes on the rebased branch
 - **NEVER** skip the GraphQL PR validation check
 - **NEVER** use `git branch -D` without first confirming `state=MERGED`
 - **NEVER** fix issues inline — if validation fails, abort and suggest `/finalize-pr`
+- **NEVER** run this skill's push step against `main` on a git-flow repo — the
+  Prerequisite step must have already refused; if it didn't, stop and re-check
 
 ## Edge Cases
 
@@ -171,15 +209,16 @@ git add {conflicted-files}
 git rebase --continue
 ```
 
-**Push to main rejected (code scanning):**
+**Push to base branch rejected (code scanning):**
 Wait for CI with `gh pr checks <PR_NUMBER> --watch --interval 15`, then retry push.
 
 **PR already merged:**
 Skip Steps 1–6. Go directly to Step 7 cleanup.
 
 **merge-base --is-ancestor exits non-zero:**
-Main moved while you were waiting for CI. Return to Step 2, re-sync main, re-fetch branch,
-re-rebase, force-push again, wait for CI, then retry merge.
+The base branch moved while you were waiting for CI. Return to Step 2, re-sync
+the base branch, re-fetch branch, re-rebase, force-push again, wait for CI,
+then retry merge.
 
 ### Pre-Push Hook Auto-Fixes Files
 
@@ -199,6 +238,7 @@ This commonly occurs with release-please CHANGELOG.md entries that don't conform
 
 - **squash-merge-pr** (github-workflows) — Squash merge after rebase-pr prepares the branch
 - **finalize-pr** (github-workflows) — Full PR finalization pipeline that may invoke rebase-pr
-- **sync-main** (git-workflows) — Syncs main branch, often needed before rebasing
+- **promote-release** (github-workflows) — The develop → main merge-commit path this skill refuses to substitute for
+- **sync-main** (git-workflows) — Syncs the default branch, often needed before rebasing
 - **pr-standards** (git-standards) — PR creation and review standards
-- **gh-cli-patterns** (github-workflows) — Canonical gh CLI command shapes, placeholder convention, PR-readiness gate
+- **gh-cli-patterns** (github-workflows) — Canonical gh CLI command shapes, placeholder convention, PR-readiness gate, default-branch detection

--- a/github-workflows/skills/refresh-repo/SKILL.md
+++ b/github-workflows/skills/refresh-repo/SKILL.md
@@ -150,14 +150,16 @@ safety.
 
 ### `--sweep [<repo-glob>]`
 
-Multi-repo cleanup of abandoned local branches. For every main worktree
-in your workspace (caller can pass a custom glob if their layout differs),
-for every local branch where `git log origin/main..HEAD` is non-empty:
+Multi-repo cleanup of abandoned local branches. For every default-branch
+worktree in your workspace (caller can pass a custom glob if their layout
+differs), resolve that repo's own default branch first (per Step 3 above —
+`main` on trunk repos, `develop` on git-flow repos), then for every local
+branch where `git log origin/<default>..HEAD` is non-empty:
 
 1. **Content-equivalence check**: compute merge base, diff each touched file
-   against current `origin/main`. If every touched file is content-equivalent
-   to (or older than) `origin/main`, delete the branch and its worktree.
-   Already-on-main contributions do not deserve a PR.
+   against current `origin/<default>`. If every touched file is content-equivalent
+   to (or older than) `origin/<default>`, delete the branch and its worktree.
+   Already-on-the-default-branch contributions do not deserve a PR.
 2. **Workaround filter**: if the diff (a) modifies 1 of N files sharing a
    common shape with no written rationale for the asymmetry, or (b) references
    a "sync mechanism" / "auto-update" by name that `grep -r <name> .` returns
@@ -196,7 +198,7 @@ explicit refspec prune and can delete local-only tags that are not release artif
 
 ## Related Skills
 
-- **sync-main** (git-workflows) — Syncs main and merges into current or all PR branches
+- **sync-main** (git-workflows) — Syncs the default branch and merges into current or all PR branches
 - **rebase-pr** (github-workflows) — Rebase-merge workflow for merging individual PRs
 - **git-workflow-standards** (git-standards) — Worktree structure and branch hygiene conventions
-- **gh-cli-patterns** (github-workflows) — Canonical gh CLI command shapes, placeholder convention, PR-readiness gate
+- **gh-cli-patterns** (github-workflows) — Canonical gh CLI command shapes, placeholder convention, PR-readiness gate, default-branch detection

--- a/github-workflows/skills/ship/SKILL.md
+++ b/github-workflows/skills/ship/SKILL.md
@@ -55,7 +55,8 @@ git status --porcelain
 
 **If changes exist** (staged or unstaged), execute inline:
 
-1. Create branch if on main: `git checkout -b {type}/{description}` (derive from changes)
+1. Create branch if on the default branch (see /gh-cli-patterns Canonical
+   Default-Branch Detection): `git checkout -b {type}/{description}` (derive from changes)
 2. Stage changes: `git add <relevant files>` (no `-A` — be selective)
 3. Commit with conventional commit message: `git commit -m "type: description"`
 4. **Simplify**: Invoke /simplify on all changes in the commit. If /simplify produces

--- a/github-workflows/skills/squash-merge-pr/SKILL.md
+++ b/github-workflows/skills/squash-merge-pr/SKILL.md
@@ -1,8 +1,9 @@
 ---
 name: squash-merge-pr
 description: >-
-  Squash-merge a PR into main. Invoke only when the user explicitly requests a
-  squash merge. Single PR by number or current branch.
+  Squash-merge a PR into its base branch. Invoke only when the user explicitly
+  requests a squash merge. Single PR by number or current branch. Refuses on
+  git-flow repos when the base is main — use /promote-release there instead.
 metadata:
   argument-hint: "[PR_NUMBER]"
 ---
@@ -21,6 +22,27 @@ draft, unresolvable conflicts, unrecoverable CI, or more than 100 review threads
 - Run the GraphQL readiness gate on every invocation before merging
 - PR metadata updates are `/finalize-pr`'s responsibility
 - Invoke `/finalize-pr` for soft blocks; abort on hard stops with reason
+- Squash is never used to merge into `main` on a git-flow repo — Step 0 guards this
+
+## Step 0: Refuse Squash Into Main On Git-Flow Repos
+
+Resolve the PR's base branch and the repo's default branch:
+
+```bash
+BASE_BRANCH=$(gh pr view <PR_NUMBER> --json baseRefName --jq '.baseRefName')
+DEFAULT_BRANCH=$(gh repo view --json defaultBranchRef --jq '.defaultBranchRef.name')
+```
+
+If `BASE_BRANCH == main` AND `DEFAULT_BRANCH == develop` (repo is on git-flow —
+see /gh-cli-patterns Canonical Default-Branch Detection), **abort immediately,
+no finalize**:
+
+> "This is a `develop` → `main` promotion PR on a git-flow repo. `main` accepts
+> merge commits only — squash and rebase are banned by ruleset, no exceptions.
+> Run `/promote-release` instead, or merge manually with `gh pr merge --merge`."
+
+Otherwise (trunk repo, or a git-flow repo's ordinary feature PR into `develop`),
+continue to Step 1 — squash-merge remains the default there.
 
 ## Step 1: Validate PR Ready
 
@@ -59,12 +81,12 @@ abort with the specific failing field.
 ## Step 2: Generate Squash Commit Message
 
 Analyze the full changeset to generate a release-note-friendly commit message.
-Replace `<PR_NUMBER>` before running:
+Replace `<PR_NUMBER>` and `<BASE_BRANCH>` (from Step 0) before running:
 
 ```bash
-git fetch origin main
-git diff origin/main...HEAD
-git log --oneline origin/main..HEAD
+git fetch origin <BASE_BRANCH>
+git diff origin/<BASE_BRANCH>...HEAD
+git log --oneline origin/<BASE_BRANCH>..HEAD
 ```
 
 Generate:
@@ -119,11 +141,11 @@ Delete the local branch ref (safe no-op if absent):
 git branch -d "$BRANCH" || true
 ```
 
-## Step 4: Sync Main
+## Step 4: Sync Base Branch
 
 ```bash
-git switch main
-git pull origin main
+git switch <BASE_BRANCH>
+git pull origin <BASE_BRANCH>
 git worktree prune
 ```
 
@@ -140,5 +162,6 @@ Invoke at any time — auto-finalizes if needed:
 
 - finalize-pr (github-workflows) — invoked automatically by squash-merge-pr when blockers are found
 - rebase-pr (github-workflows) — alternative merge strategy that preserves commit history
+- promote-release (github-workflows) — the develop → main merge-commit path this skill refuses to substitute for
 - pr-standards (git-standards) — PR authoring and review standards
-- gh-cli-patterns (github-workflows) — canonical gh CLI command shapes, placeholder convention, PR-readiness gate
+- gh-cli-patterns (github-workflows) — canonical gh CLI command shapes, placeholder convention, PR-readiness gate, default-branch detection


### PR DESCRIPTION
## Summary

Makes the `github-workflows`, `git-workflows`, and `git-standards` plugin skills detect a repo's
branch model (trunk vs [git-flow](https://github.com/dryvist/ai-assistant-instructions/blob/main/agentsmd/rules/git-flow.md))
instead of hardcoding `main` as the PR base, sync target, or merge target.
Trunk-repo behavior (default branch `main`) is unchanged throughout.

## Changes

**github-workflows**

- `gh-cli-patterns` — new canonical default-branch detection section other skills reference
- `ship` — generalizes the on-default-branch check before creating a feature branch
- `finalize-pr` — fetches the PR's actual `baseRefName` instead of assuming `main`
- `squash-merge-pr` — refuses to squash a `develop` → `main` promotion PR on a git-flow repo (main is merge-commit-only); otherwise generalized to the PR's base branch
- `rebase-pr` — refuses its direct-push-to-base technique when the base is `main` on a git-flow repo (direct pushes to main are banned there); otherwise generalized to the PR's base branch
- `refresh-repo` — `--sweep` mode now resolves each repo's own default branch instead of assuming `main`
- `promote-release` (new) — merge-commit-only `develop` → `main` promotion PR; release-please takes over versioning after merge

**git-workflows**

- `sync-main` — keeps its name, but now syncs the repo's actual default branch (`develop` on git-flow repos); adds a git-flow-only step that fast-forwards a local `main` worktree read-only
- `wrap-up` — `purge-pr` mode switches to the resolved default branch instead of a literal `main`
- `troubleshoot-rebase` — generalizes rebase/reset targets to the resolved default branch, with a git-flow note that `main` is never a rebase target
- `troubleshoot-worktree` — notes the ambiguous-refname pattern also applies to `origin/develop`

**git-standards**

- `git-workflow-standards` — worktree guidance, branch hygiene, and the sync workflow all generalized to the repo's default branch; also fixes a stale plugin label (`refresh-repo` lives in `github-workflows`, not `git-workflows`)

**Audited, no changes needed**: `resolve-pr-threads`, `trigger-ai-reviews`,
`shape-issues`, `shared-workflow-org-refs` (no base-branch dependency);
`troubleshoot-precommit`, `pre-commit-architecture` (no base-branch dependency
— the latter's `main` reference is a link into another repo's docs, not a
merge target); `git-guards` (its `current_branch == "main"` checks are correct
under both models — git-flow's `main` is even more locked down than trunk's,
and git-flow explicitly permits direct commits to `develop`, so extending the
guard there would be wrong, not a gap).

## Test plan

- [x] `markdownlint-cli2` clean on every changed file (0 errors)
- [x] `jq empty` on the modified `plugin.json`
- [ ] Exercise `/squash-merge-pr` and `/rebase-pr` against a real git-flow pilot repo PR targeting `main`, confirm the refusal message and that `/promote-release` completes the merge
- [ ] Exercise `/sync-main` on a git-flow repo, confirm it syncs `develop` and fast-forwards local `main`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Assisted-by: Claude:claude-sonnet-5
Claude-Session: https://claude.ai/code/session_01D9EGoFt6YZvquAVYFZURtQ