### PR TITLE
fix(promote-release): drop angle bracket from skill description

### DIFF
--- a/github-workflows/skills/promote-release/SKILL.md
+++ b/github-workflows/skills/promote-release/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: promote-release
 description: >-
-  Open and merge a develop -> main promotion PR on a git-flow repo. Merge
+  Open and merge a develop-to-main promotion PR on a git-flow repo. Merge
   commit only, never squash or rebase — main accepts merge commits only.
   Every merge to main triggers release-please, which takes over tagging and
   release notes from there. Refuses on trunk repos (default branch main) —


### PR DESCRIPTION
Anthropic's skill validator rejects `<`/`>` in frontmatter descriptions; the `develop -> main` arrow made `validate` fail on every PR. Introduced in #380.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01D9EGoFt6YZvquAVYFZURtQ