### PR TITLE
fix(content-guards): restore Python 3.9 compatibility in hook scripts

### DIFF
--- a/.github/workflows/validate-plugin.yml
+++ b/.github/workflows/validate-plugin.yml
@@ -124,3 +124,21 @@ jobs:
               python3 "$test"
             fi
           done
+
+  # Hooks run on user machines via `#!/usr/bin/env python3`, which on macOS is the
+  # system Python 3.9. The py_compile step above only checks SYNTAX — PEP 604
+  # unions (`X | None`) are valid syntax but crash at runtime on <3.10. Import each
+  # hook module under 3.9 to catch that runtime breakage before release.
+  hook-runtime-py39:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
+
+      - name: Setup Python 3.9
+        uses: actions/setup-python@v6
+        with:
+          python-version: '3.9'
+
+      - name: Import hook scripts under Python 3.9
+        run: ./scripts/check-hooks-py39.sh

--- a/content-guards/scripts/enforce-issue-limits.py
+++ b/content-guards/scripts/enforce-issue-limits.py
@@ -22,6 +22,8 @@ Exit codes:
 Input: JSON from stdin with tool_input.command containing the Bash command
 """
 
+from __future__ import annotations
+
 import json
 import os
 import re

--- a/content-guards/scripts/validate-readme.py
+++ b/content-guards/scripts/validate-readme.py
@@ -13,6 +13,8 @@ Exit codes:
 Input: JSON from stdin with tool_input.file_path containing the edited file
 """
 
+from __future__ import annotations
+
 import json
 import re
 import sys

--- a/content-guards/scripts/validate-token-limits.py
+++ b/content-guards/scripts/validate-token-limits.py
@@ -5,6 +5,8 @@ Blocks file modifications (Write/Edit tools) that would exceed token limits.
 
 Configuration: .token-limits.yaml (searches upward from cwd)
 """
+from __future__ import annotations
+
 import fnmatch
 import json
 import re

--- a/scripts/check-hooks-py39.sh
+++ b/scripts/check-hooks-py39.sh
@@ -1,0 +1,26 @@
+#!/usr/bin/env bash
+# Import every hook script under the active Python to catch runtime breakage that
+# `py_compile` (syntax-only) misses — notably PEP 604 unions (`X | None`), which
+# are valid syntax but raise TypeError at runtime on Python < 3.10. Hooks run on
+# user machines via `#!/usr/bin/env python3`; on macOS that is the system Python
+# 3.9, so this check is meant to run under 3.9 in CI. Importing (not executing)
+# each module evaluates its annotations and top-level code; main() is
+# __name__-guarded, so nothing runs.
+set -euo pipefail
+
+echo "Importing hook scripts under $(python3 --version)..."
+rc=0
+while IFS= read -r script; do
+  [ -f "$script" ] || continue
+  echo "Importing: $script"
+  if ! python3 -c "
+import importlib.util, sys
+spec = importlib.util.spec_from_file_location('hook', sys.argv[1])
+mod = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(mod)
+" "$script"; then
+    echo "ERROR: $script fails to import under $(python3 --version)"
+    rc=1
+  fi
+done < <(find . -name "*.py" -path "*/scripts/*" ! -name "test_*")
+exit "$rc"


### PR DESCRIPTION
## Problem

Every Claude Code session on macOS was spamming:

\`\`\`
PreToolUse:Bash hook error
Failed with non-blocking status code: Traceback (most recent call last):
\`\`\`

Three \`content-guards\` hook scripts use PEP 604 union syntax (\`X | None\`) in
runtime-evaluated function annotations, which requires Python >= 3.10. Hooks run
via \`#!/usr/bin/env python3\`; on macOS that resolves to the system Python 3.9,
where the annotation evaluates at import time and raises
\`TypeError: unsupported operand type(s) for |\`, aborting the hook:

| Script | Hook | Fired on |
| --- | --- | --- |
| \`enforce-issue-limits.py\` | \`PreToolUse:Bash\` | every Bash command |
| \`validate-token-limits.py\` | \`PreToolUse:Write\|Edit\` | every Write/Edit |
| \`validate-readme.py\` | \`PostToolUse:Write\|Edit\` | every Write/Edit (and the skill) |

## Fix

Add \`from __future__ import annotations\` (PEP 563) to each affected script so
annotations are stored as strings and never evaluated at runtime. All unions here
are annotation-only, so this fully resolves the crash with no behavior change.

## Why CI missed it

\`validate-plugin.yml\` set up Python 3.14 and only ran \`py_compile\` (syntax check).
PEP 604 is valid *syntax*; the failure is a *runtime* error, and 3.14 evaluates
the union fine. Added a \`hook-runtime-py39\` job that **imports** every hook script
under Python 3.9 (\`main()\` is \`__name__\`-guarded, so only annotations/top-level
evaluate). Logic lives in \`scripts/check-hooks-py39.sh\` per the
no-complex-inline-bash-in-workflow-YAML convention.

## Verification

- All three scripts import cleanly under system Python 3.9.6 (pre-fix: TypeError traceback).
- Existing \`content-guards/scripts/test_*.py\` pass under 3.9.
- New CI guard passes locally against all 8 hook scripts.

🤖 Generated with [Claude Code](https://claude.com/claude-code)