### PR TITLE
fix(git-standards): resolve default branch in pr-standards guards

### DIFF
--- a/git-standards/skills/pr-standards/SKILL.md
+++ b/git-standards/skills/pr-standards/SKILL.md
@@ -7,7 +7,9 @@ description: Use when creating PRs, linking issues, managing PR comments, or cre
 
 ## PR Creation Guards
 
-Run these checks in order before `gh pr create`:
+Run these checks in order before `gh pr create`. Replace `<default>` with the
+repo's actual default branch — `main` on a trunk repo, `develop` on a git-flow
+repo (see `gh-cli-patterns`, github-workflows, for detection).
 
 **Guard 1 — Check for merged twin** (prevents zombie PRs):
 
@@ -15,7 +17,7 @@ Run these checks in order before `gh pr create`:
 gh pr list --repo JacobPEvans/<repo> --state merged --head <branch>
 ```
 
-If merged PR exists AND `git log origin/main..HEAD --oneline` is empty:
+If merged PR exists AND `git log origin/<default>..HEAD --oneline` is empty:
 STOP. Remove stale worktree.
 
 **Guard 2 — Check for existing open PR** (prevents duplicates):
@@ -38,7 +40,7 @@ Include `Closes #X` or `Related to #X` in PR body. After creation:
 **Guard 4 — Validate branch has commits**:
 
 ```bash
-git log origin/main..HEAD --oneline
+git log origin/<default>..HEAD --oneline
 ```
 
 If empty: no new work. Clean up instead.
@@ -173,3 +175,4 @@ Every issue MUST have explicit, checkbox-format acceptance criteria.
 - **rebase-pr** (git-workflows) — Rebase-merge workflow for merging approved PRs
 - **finalize-pr** (github-workflows) — Finalize PR state before merging
 - **git-workflow-standards** (git-standards) — Branch and worktree conventions that feed into PRs
+- **gh-cli-patterns** (github-workflows) — Canonical default-branch detection (trunk vs git-flow)


### PR DESCRIPTION
## Summary

Follow-up to #380 (git-flow-aware branch targets) and the #381 residual sweep.
The `pr-standards` skill's PR-creation guards still hardcoded `origin/main..HEAD`
for the "does this branch have commits beyond the default branch" check. #380
generalized the identical check in the sibling `git-workflow-standards` skill
(line 23) but missed this one in `pr-standards` — so on a git-flow repo
(default `develop`) Guards 1 and 4 compare against the wrong base.

## Changes

`git-standards/skills/pr-standards/SKILL.md`:
- Guard 1 (L18) and Guard 4 (L41): `origin/main..HEAD` -> `origin/<default>..HEAD`
- Document the `<default>` placeholder once, mirroring `git-workflow-standards`
- Add `gh-cli-patterns` to Related Skills for the detection reference

Trunk-repo behavior (default `main`) is unchanged.

## Scope notes on #381 (why this is `Related`, not `Closes`)

The #381 sweep flagged three residuals; this PR handles the one genuine,
in-repo branch-target leak and deliberately leaves the other two:

- **git-workflow-standards skill** — already generalized in #380; nothing left.
- **git-guards diagram + `current_branch == "main"` checks** — intentionally
  left as-is. git-flow's `main` is release-only (more locked down than trunk's)
  and direct commits to `develop` are permitted, so extending the guard to the
  default branch would be *wrong*, not a gap. #380's audit reached the same
  conclusion. The diagram accurately reflects the (correct) code; rewording it
  to "default branch" would make it inaccurate.
- **ai-assistant-instructions `scripts/cleanup-stale-branches.sh`** (3 refs,
  `git branch --merged main`) — a real git-flow gap, but a different repo, so it
  cannot ride in this PR. Needs a separate PR there.

So #381 stays open for the aai-script fix + a wontfix note on the diagram item.

## Test plan

- [x] `markdownlint-cli2` clean (0 errors)
- [x] `pre-commit run --files` on the changed file — all hooks pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)