### PR TITLE
docs: route infrastructure orchestration through Terrakube

### DIFF
--- a/git-workflows/skills/pre-commit-architecture/SKILL.md
+++ b/git-workflows/skills/pre-commit-architecture/SKILL.md
@@ -125,8 +125,8 @@ pre-commit install
   external modules. `nix flake check` runs hooks in a sandboxed
   environment without network. Repos with external module references
   override `terraform-validate.enable = lib.mkForce false` for the
-  flake-check path and rely on CI's OIDC-authenticated
-  `terragrunt validate` to cover the check.
+  flake-check path and rely on CI's offline `tofu validate` gate to cover the
+  check. Credentialed plans run in the homelab Terrakube workspace.
 - `gitleaks` is not in `cachix/git-hooks.nix`'s built-in hook set yet.
   Consumers that want it wire it as a custom hook locally; a follow-up
   adds it to the base profile.

--- a/infra-orchestration/skills/orchestrate-infra/SKILL.md
+++ b/infra-orchestration/skills/orchestrate-infra/SKILL.md
@@ -11,23 +11,25 @@ between Terraform and Ansible repositories and dispatches Task subagents for eac
 ## Dependency Graph
 
 ```text
-terraform-proxmox
+tofu-proxmox
   -> ansible-proxmox (host configuration)
   -> ansible-proxmox-apps (application configuration)
      -> ansible-splunk (Splunk Enterprise)
 ```
 
-Terraform provisions infrastructure first. Ansible configures it in dependency order.
+OpenTofu provisions infrastructure first through Terrakube. Ansible configures it in dependency order.
 
 ## Supported Operations
 
 ### plan-all
 
-Run `terragrunt plan` in terraform-proxmox, then `ansible-playbook --check` across all Ansible repos in dependency order.
+Run `tofu plan` in the `tofu-proxmox` Terrakube workspace, then
+`ansible-playbook --check` across all Ansible repos in dependency order.
 
 ### validate-all
 
-Run `terragrunt validate` in terraform-proxmox, then `ansible-playbook --syntax-check` across all Ansible repos.
+Run `tofu validate` in tofu-proxmox, then `ansible-playbook --syntax-check`
+across all Ansible repos.
 
 ### sync-inventory
 
@@ -40,15 +42,17 @@ Full pipeline validation: validate, plan, export inventory, syntax-check, check,
 ## Execution Pattern
 
 1. **Resolve repo paths**: locate each target repo locally
-2. **Dispatch Terraform phase**: Launch subagent for terraform-proxmox operations
-3. **Await completion**: Terraform must complete before Ansible phases
+2. **Dispatch OpenTofu phase**: Launch a subagent for tofu-proxmox operations
+3. **Await completion**: OpenTofu must complete before Ansible phases
 4. **Dispatch Ansible phases**: Launch parallel subagents for independent Ansible repos (invoke `superpowers:dispatching-parallel-agents`)
 5. **Collect results**: Aggregate success/failure from all subagents
 6. **Report**: Summary with per-repo status
 
 ## Secret Injection
 
-All repos use Doppler for runtime secrets: `doppler run -- <command>`. Never hardcode credentials.
+Terrakube obtains short-lived OpenBao credentials through its native dynamic
+provider credential flow. Ansible uses native OpenBao lookups under its own
+policy. Never export, copy, or hardcode runtime credentials.
 
 ## Error Handling
 

--- a/infra-orchestration/skills/sync-inventory/SKILL.md
+++ b/infra-orchestration/skills/sync-inventory/SKILL.md
@@ -1,29 +1,25 @@
 ---
 name: sync-inventory
-description: Verify or refresh the Terraform-to-Ansible inventory distribution (S3-published; apply is the publish boundary)
+description: Verify or refresh the OpenTofu-to-Ansible inventory distribution (RustFS-published; apply is the publish boundary)
 ---
 
 # Infrastructure Sync Inventory
 
-The inventory pipeline is **automatic**: every terraform-proxmox
-`terragrunt apply` natively publishes the `ansible_inventory` output to the
-versioned S3 state bucket (`inventory_publish.tf`, `aws_s3_object`), and the
-apply's after-hook (`scripts/sync-inventory.sh`) validates it against the
-schema, PRs a versioned mirror into the private data repo (gated on
-`INVENTORY_DATA_REPO`), and warms the local gitignored
-`inventory/tofu_inventory.json` cache in each consumer repo.
+The inventory pipeline is **automatic**: every successful `tofu-proxmox`
+Terrakube apply validates `ansible_inventory` in the OpenTofu graph and
+publishes it to the homelab RustFS object store with `aws_s3_object`. There is
+no post-apply hook or manual mirror step.
 
 Consumers (`ansible-proxmox`, `ansible-proxmox-apps`, `ansible-splunk`) resolve
 identically via their `load_tofu.yml`:
 
 1. `TOFU_INVENTORY_PATH` — explicit pin (tests/overrides)
-2. **S3 artifact** — native `amazon.aws` fetch; AWS read creds only, no
-   checkout, no toolchain (`TOFU_INVENTORY_S3_URI` / `TOFU_INVENTORY_S3_REGION`
-   override location/region)
-3. Local cache — the after-hook copy
+2. **RustFS artifact** — native `amazon.aws` fetch over the homelab network;
+   scoped credentials come from OpenBao, with no IaC checkout or toolchain
+3. Local cache — offline fallback only
 
 **There is no manual export/transform/copy flow.** Never run
-`terragrunt output -json ansible_inventory > <consumer>/inventory/...` by hand —
+`tofu output -json ansible_inventory > <consumer>/inventory/...` by hand —
 hand-injected inventories bypass the schema gate and create unmanaged drift.
 
 ## When invoked, do this
@@ -32,26 +28,28 @@ hand-injected inventories bypass the schema gate and create unmanaged drift.
 
 ```bash
 aws s3api head-object \
-  --bucket "terraform-proxmox-state-useast2-<account-id>" \
-  --key terraform-proxmox/inventory/ansible_inventory.json \
+  --endpoint-url "$RUSTFS_ENDPOINT" \
+  --bucket "$TOFU_INVENTORY_BUCKET" \
+  --key "$TOFU_INVENTORY_KEY" \
   --query LastModified
 ```
 
 If it predates the last intended infrastructure change, the publish boundary
 was not crossed — run a real apply (next step). Reference docs:
-`terraform-proxmox/docs/INVENTORY_PUBLISHING.md`.
+`tofu-proxmox/docs/INVENTORY_PUBLISHING.md`.
 
 ### 2. Refresh = apply
 
 The only way to republish is the publish boundary itself:
 
 ```bash
-cd ${GIT_HOME_PUBLIC}/terraform-proxmox/main
-aws-vault exec tf-proxmox -- doppler run -- terragrunt apply
+cd ${GIT_HOME_PUBLIC}/homelab/tofu-proxmox/main
+tofu apply
 ```
 
-The apply updates the S3 object (only when content changed) and the after-hook
-re-warms every local cache and refreshes the int_homelab mirror PR.
+The command submits a remote Terrakube run. The workspace lock serializes
+changes, Terrakube obtains its OpenBao credentials natively, and the apply
+updates the RustFS object only when content changed.
 
 ### 3. Validate consumers resolve
 
@@ -68,10 +66,10 @@ Watch which resolution step wins ("Resolve inventory from …" task output).
 
 ## Error Handling
 
-- Schema-gate failure in the after-hook → the source output is partial
-  (e.g. a `-target` apply); fix the apply, never hand-edit the artifact.
-- S3 fetch fails for a consumer → it degrades to the local cache by design;
-  give the runner scoped `s3:GetObject` creds to restore the cloud path.
+- Schema-gate failure in the OpenTofu graph → the source output is invalid;
+  fix the configuration, never hand-edit the artifact.
+- RustFS fetch fails for a consumer → it degrades to the local cache by design;
+  restore homelab reachability or the consumer's scoped OpenBao policy.
 - Missing local cache + no creds → set `TOFU_INVENTORY_PATH` to a known-good
   copy, or run the apply.
 

--- a/infra-orchestration/skills/test-e2e/SKILL.md
+++ b/infra-orchestration/skills/test-e2e/SKILL.md
@@ -10,32 +10,33 @@ Validates syntax, plans changes, exports inventory, and dry-runs Ansible playboo
 
 ## Pipeline Stages
 
-### Stage 1: Terraform Validate
+### Stage 1: OpenTofu Validate
 
-In `terraform-proxmox`:
+In `tofu-proxmox`:
 
 ```bash
-doppler run -- terragrunt validate
+tofu validate
 ```
 
-### Stage 2: Terraform Plan
+### Stage 2: Terrakube Plan
 
-In `terraform-proxmox`:
+In `tofu-proxmox`:
 
 ```bash
-doppler run -- terragrunt plan
+tofu plan
 ```
 
 ### Stage 3: Export Inventory
 
-Run `/infra-sync-inventory` to export Terraform outputs and distribute to Ansible repos.
+Run `/infra-sync-inventory` to verify the RustFS artifact produced by the last
+successful Terrakube apply.
 
 ### Stage 4: Ansible Syntax Check
 
 Run in parallel across all Ansible repos:
 
 ```bash
-doppler run -- ansible-playbook --syntax-check -i inventory/hosts.yml playbooks/site.yml
+ansible-playbook --syntax-check -i inventory/hosts.yml playbooks/site.yml
 ```
 
 Target repos: ansible-proxmox, ansible-proxmox-apps, ansible-splunk
@@ -45,7 +46,7 @@ Target repos: ansible-proxmox, ansible-proxmox-apps, ansible-splunk
 Run in parallel across all Ansible repos:
 
 ```bash
-doppler run -- ansible-playbook --check -i inventory/hosts.yml playbooks/site.yml
+ansible-playbook --check -i inventory/hosts.yml playbooks/site.yml
 ```
 
 ### Stage 6: Ansible Diff
@@ -53,14 +54,14 @@ doppler run -- ansible-playbook --check -i inventory/hosts.yml playbooks/site.ym
 Run in parallel across all Ansible repos:
 
 ```bash
-doppler run -- ansible-playbook --check --diff -i inventory/hosts.yml playbooks/site.yml
+ansible-playbook --check --diff -i inventory/hosts.yml playbooks/site.yml
 ```
 
 ## Results
 
 Report per-stage, per-repo pass/fail status:
 
-| Stage | terraform-proxmox | ansible-proxmox | ansible-proxmox-apps | ansible-splunk |
+| Stage | tofu-proxmox | ansible-proxmox | ansible-proxmox-apps | ansible-splunk |
 | --- | --- | --- | --- | --- |
 | Validate | PASS/FAIL | - | - | - |
 | Plan | PASS/FAIL | - | - | - |
@@ -70,7 +71,7 @@ Report per-stage, per-repo pass/fail status:
 
 ## Error Handling
 
-Stage failures in Terraform block all subsequent stages. Ansible stage failures are independent per-repo.
+Stage failures in OpenTofu block all subsequent stages. Ansible stage failures are independent per-repo.
 
 ## Related Skills
 


### PR DESCRIPTION
## Summary\n\nPart of the coordinated dryvist fleet migration to native OpenTofu execution in the homelab Terrakube control plane, with Terrakube workspace locking and short-lived OpenBao workload identity.\n\n## Safety\n\n- Draft only; do not merge independently.\n- No production apply or state migration was performed.\n- State migration requires an approved window, refresh-only proof, and rollback snapshot.\n- General WAN egress remains blocked as a release gate until the homelab artifact mirror is seeded and validated.