### PR TITLE
feat(ai-delegation): make premium-agent-orchestration model-universal

### DIFF
--- a/ai-delegation/README.md
+++ b/ai-delegation/README.md
@@ -6,7 +6,8 @@ Claude Code plugin for delegating tasks to AI models, orchestrating premium-mode
 
 - **`/delegate-to-ai`** - Route a task to the right model (native subagent, Codex, or local MLX) based on task type
 - **`/auto-maintain`** - Autonomous maintenance orchestrator that continuously finds and dispatches work
-- **`/premium-agent-orchestration`** - Preserve Fable, Opus, and other top-tier model reasoning
+- **`/premium-agent-orchestration`** - Preserve top-tier/SOTA model reasoning (any vendor,
+  current or future — the session's own model is assumed to be the premium lead)
   for judgment while delegating checkable work to cheaper agents, local LLMs, or free tiers
 
 ## Installation

--- a/ai-delegation/skills/premium-agent-orchestration/SKILL.md
+++ b/ai-delegation/skills/premium-agent-orchestration/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: premium-agent-orchestration
-description: This skill should be used when the active session is running a premium top-tier/SOTA model — from any vendor, current or future — and the work should preserve premium reasoning for intent, architecture, decomposition, tradeoffs, final review, and synthesis while delegating checkable discovery, implementation, verification, logs, tests, and repetitive work to cheaper agents or local/free LLMs. Assume the model running this session IS the premium lead.
+description: Use when the session runs a premium top-tier/SOTA model (any vendor, current or future — the session's model IS the premium lead). Keeps premium reasoning on judgment (intent, architecture, tradeoffs, final review) and delegates checkable labor to cheaper agents or local/free LLMs.
 ---
 
 # Premium Agent Orchestration

--- a/ai-delegation/skills/premium-agent-orchestration/SKILL.md
+++ b/ai-delegation/skills/premium-agent-orchestration/SKILL.md
@@ -1,13 +1,15 @@
 ---
 name: premium-agent-orchestration
-description: This skill should be used when the active agent is Fable 5, Opus, or another expensive top-tier/SOTA model and the work should preserve premium reasoning for intent, architecture, decomposition, tradeoffs, final review, and synthesis while delegating checkable discovery, implementation, verification, logs, tests, and repetitive work to cheaper agents or local/free LLMs.
+description: This skill should be used when the active session is running a premium top-tier/SOTA model — from any vendor, current or future — and the work should preserve premium reasoning for intent, architecture, decomposition, tradeoffs, final review, and synthesis while delegating checkable discovery, implementation, verification, logs, tests, and repetitive work to cheaper agents or local/free LLMs. Assume the model running this session IS the premium lead.
 ---
 
 # Premium Agent Orchestration
 
-Treat the active premium model as the senior decision-maker. Spend premium
-reasoning only where stronger judgment changes the outcome, and route
-checkable labor to the cheapest capable executor.
+Treat the model running the current session as the senior decision-maker,
+whatever it is — the skill is model- and vendor-agnostic and applies equally
+to any present or future top-tier model. Spend premium reasoning only where
+stronger judgment changes the outcome, and route checkable labor to the
+cheapest capable executor.
 
 ## Purpose
 
@@ -21,7 +23,7 @@ lowest-cost executor that can reliably produce that evidence.
 
 ## Senior Model Owns
 
-Keep these decisions with the premium model:
+Keep these decisions with the premium lead (the current session's model):
 
 - Understand the real user intent.
 - Decide what matters and what is out of scope.
@@ -37,15 +39,24 @@ Keep these decisions with the premium model:
 
 ## Delegation Tiers
 
+Tiers are **capability roles, not model names**. Resolve each role against
+whatever models the current environment actually offers (native subagent
+model options, configured CLIs, local serving); never assume a specific
+vendor's lineup.
+
 Delegate work whose output can be verified from evidence.
 
 | Tier | Use for | Boundary |
 | --- | --- | --- |
-| Local/free LLM | File discovery, log summaries, simple scans, checklist verification, cheap summaries | Report facts and evidence; avoid product or architecture calls |
-| Haiku-class | Repo discovery, large-file summaries, log inspection, simple checks, edge-case scanning | Report facts, not direction |
-| Sonnet-class | Scoped implementation, tests, medium debugging, local refactors, following existing patterns | Execute the plan; avoid changing architecture or product intent |
-| Opus-class | Complex implementation, deep debugging, cross-module reasoning, risky review, security-sensitive reasoning | Reason deeply, but leave final authority with the premium lead |
+| Local/free | File discovery, log summaries, simple scans, checklist verification, cheap summaries | Report facts and evidence; avoid product or architecture calls |
+| Small/cheap cloud | Repo discovery, large-file summaries, log inspection, simple checks, edge-case scanning | Report facts, not direction |
+| Mid execution | Scoped implementation, tests, medium debugging, local refactors, following existing patterns | Execute the plan; avoid changing architecture or product intent |
+| Strong reasoning | Complex implementation, deep debugging, cross-module reasoning, risky review, security-sensitive reasoning | Reason deeply, but leave final authority with the premium lead |
 | Premium lead | Intent, architecture, decomposition, tradeoffs, risk, disagreement, final review, synthesis | Own final decisions and user communication |
+
+The strong-reasoning tier may be the same model as the premium lead when no
+cheaper strong model is available — the split is about role and context
+isolation, not necessarily price.
 
 ## Local And Free-Tier First
 
@@ -66,8 +77,9 @@ Prefer these routes in order for simple checkable work:
    access, reliability, or reasoning quality.
 
 Discover current model availability live. Do not hard-code physical model IDs,
-provider names, or static task-to-model tables. Use capability roles, local
-registry data, or live model listing when available.
+provider names, or static task-to-model tables — including for the premium
+lead itself. Use capability roles, local registry data, or live model listing
+when available.
 
 ## Boundary
 
@@ -97,9 +109,9 @@ Treat these areas as high-risk:
 - Public APIs.
 - User-visible workflows.
 
-For high-risk work, keep the decision with the premium lead, use an Opus-class
-agent for the hardest technical execution or review, and use cheaper agents or
-local/free models to verify concrete evidence.
+For high-risk work, keep the decision with the premium lead, use a
+strong-reasoning agent for the hardest technical execution or review, and use
+cheaper agents or local/free models to verify concrete evidence.
 
 ## Substrate Resilience (solo fallback is mandatory)
 
@@ -128,8 +140,9 @@ contract.
    solo path — the lead executes steps 5-7's work serially itself.
 5. Route checkable labor to the cheapest capable local, free, or small-model
    executor.
-6. Use Sonnet-class agents for normal scoped engineering execution.
-7. Use Opus-class agents for difficult delegated technical work or risky review.
+6. Use mid-execution-tier agents for normal scoped engineering execution.
+7. Use strong-reasoning agents for difficult delegated technical work or risky
+   review.
 8. Review each agent's evidence.
 9. Make the important decision with the premium lead.
 10. Verify non-trivial work before answering.


### PR DESCRIPTION
## What

Per direct user request: the `premium-agent-orchestration` skill assumed an Anthropic lineup ("Fable 5, Opus" in the trigger description; Haiku/Sonnet/Opus-class delegation tiers). Any premium model (e.g. a future SOTA model from another vendor) should be able to run it as the lead.

- Frontmatter description now triggers on "any premium top-tier/SOTA model, any vendor, current or future" and states the running session's model is assumed to be the premium lead.
- Delegation tiers renamed to capability roles (local/free → small/cheap cloud → mid execution → strong reasoning → premium lead), with an explicit "tiers are capability roles, not model names; resolve against what the environment actually offers" rule.
- The existing "don't hard-code model IDs" guidance now covers the premium lead itself.
- README skill blurb updated to match.

No behavioral logic changed — operating loop, substrate resilience, and gates are intact.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Rdwc5T5WAu4qoc3a3NzxkX