### PR TITLE
docs(git-flow-next): carry session id in branch and worktree names

### DIFF
--- a/git-workflows/skills/git-flow-next/SKILL.md
+++ b/git-workflows/skills/git-flow-next/SKILL.md
@@ -26,31 +26,44 @@ gh repo view --json defaultBranchRef --jq '.defaultBranchRef.name'
 | --- | --- | --- |
 | `main` | Production. Protected; no direct pushes. | **Merge commits only** — squash and rebase are banned. |
 | `develop` | Default integration branch. | Squash-merged feature PRs (default); merge commits for back-merges. |
-| `feature/<issue>-<slug>` | Topic work | Branched from fresh `develop`. |
+| `feature/<issue>-<sid8>-<slug>` | Topic work | Branched from fresh `develop`. |
 | `release/<version>` | Release stabilization | Branched from `develop`; merge-committed to `main`; back-merged to `develop`. |
 | `hotfix/<slug>` | Production fix | Branched from `main`; PR to `main` (merge commit); back-merged to `develop`. |
 
 ## 3. Dedicated Worktree Setup
 
-All feature development happens in dedicated worktrees. To prevent wrong nesting:
+All feature development happens in dedicated worktrees. Branch names carry the
+session id: `<issue>-<sid8>-<slug>`, where `<sid8>` is the first 8 hex chars of
+the session/conversation id (generate `openssl rand -hex 4` if the runtime has
+none). Issueless work drops the issue segment: `<sid8>-<slug>`. The worktree
+directory matches the branch's name segment. Unique-per-session names make
+worktree/branch collisions between concurrent sessions structurally
+impossible; refs dryvist/ai-assistant-instructions#749.
+
+To prevent wrong nesting:
 
 1. Resolve the destination path using an absolute anchor and create the branch directly in the worktree:
 
    ```bash
-   git worktree add -b "feature/<name>" "$(dirname "$(git rev-parse --git-common-dir)")/.worktrees/feature-<name>" origin/develop
+   name="123-03a3a401-fix-inventory-loader"
+   git worktree add -b "feature/$name" \
+     "$(dirname "$(git rev-parse --git-common-dir)")/.worktrees/$name" origin/develop
    ```
 
 2. The primary/root checkout remains on `develop`. Never check out feature branches at the root.
+3. **One session, one branch**: never commit to or push another session's
+   branch. A takeover continues on a NEW branch (fresh `<sid8>`), never by
+   reusing the prior session's name.
 
 ## 4. Working a Change
 
 1. Navigate to the newly created worktree directory:
 
    ```bash
-   cd "$(dirname "$(git rev-parse --git-common-dir)")/.worktrees/feature-<name>"
+   cd "$(dirname "$(git rev-parse --git-common-dir)")/.worktrees/123-03a3a401-fix-inventory-loader"
    ```
 
-   *Note*: The branch `feature/<name>` (e.g., `feature/123-fix-inventory-loader`) is already created and checked out by the worktree setup step.
+   *Note*: The branch `feature/123-03a3a401-fix-inventory-loader` is already created and checked out by the worktree setup step.
 2. Commit atomically following Conventional Commits, referencing the issue (`#123`).
 3. Open the PR targeting `develop`. Squash-merge feature PRs.
 4. **Validation**: Thoroughly test and validate the merged code on `develop` before production promotion.


### PR DESCRIPTION
## Summary

- The `git-flow-next` skill's branch/worktree naming examples (`feature/<issue>-<slug>`, `.worktrees/feature-<name>`) don't account for concurrent sessions working the same repo — two sessions picking the same slug collide on both the branch name and the worktree path.
- Adds a session-id segment to the convention: `feature/<issue>-<sid8>-<slug>` (issueless: `feature/<sid8>-<slug>`), where `<sid8>` is the first 8 hex chars of the session/conversation id. Worktree directory matches the branch's name segment.
- Documents the one-session-one-branch invariant: never commit to or push another session's branch; a takeover continues on a new branch with a fresh `<sid8>`.
- Updates the worked examples in "Dedicated Worktree Setup" and "Working a Change" to use a session-id-bearing name.

Session id for this change: `claude-mbp-p0c`.

## Scope note

Grepped the repo for other places documenting branch/worktree naming conventions (`git-workflow-standards`, `refresh-repo`, and a search for `feature/<...>` patterns generally). Only `git-flow-next/SKILL.md` states an actual naming convention; `git-workflow-standards` only references `git flow feature start` in passing with no example name, and `refresh-repo`'s `feature/<default>` mention is an unrelated example about basename-matching pitfalls in its cleanup logic — left both untouched.

## Test plan

- [x] `pre-commit run --files git-workflows/skills/git-flow-next/SKILL.md` — all hooks passed (markdown lint, YAML/JSON validation, agent-skill validation, plugin frontmatter validation)
- [ ] Reviewer confirms the updated examples read correctly in context

Refs dryvist/ai-assistant-instructions#749

🤖 Generated with [Claude Code](https://claude.com/claude-code)