### PR TITLE
feat(openbao): add openbao plugin with the secrets access-model skill

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -6,104 +6,14 @@
   },
   "metadata": {
     "description": "Claude Code plugins and hooks by JacobPEvans",
-    "version": "4.21.0"
+    "version": "4.19.0"
   },
   "plugins": [
-    {
-      "name": "git-guards",
-      "source": "./git-guards",
-      "description": "Combined git security and workflow protection via PreToolUse hooks - merges git-permission-guard and main-branch-guard functionality",
-      "version": "4.21.0",
-      "author": {
-        "name": "JacobPEvans"
-      }
-    },
-    {
-      "name": "content-guards",
-      "source": "./content-guards",
-      "description": "Combined content validation and guard plugin that merges token-validator, markdown-validator, webfetch-guard, and issue-limiter functionality",
-      "version": "4.21.0",
-      "author": {
-        "name": "JacobPEvans"
-      }
-    },
-    {
-      "name": "git-workflows",
-      "source": "./git-workflows",
-      "description": "Git worktree initialization, main branch sync, repository refresh, and troubleshooting workflows",
-      "version": "4.21.0",
-      "author": {
-        "name": "JacobPEvans"
-      }
-    },
-    {
-      "name": "github-workflows",
-      "source": "./github-workflows",
-      "description": "PR management, multi-repo PR finalization, and issue shaping with Shape Up methodology",
-      "version": "4.21.0",
-      "author": {
-        "name": "JacobPEvans"
-      }
-    },
-    {
-      "name": "infra-orchestration",
-      "source": "./infra-orchestration",
-      "description": "Cross-repo infrastructure orchestration for Terraform and Ansible workflows",
-      "version": "4.21.0",
-      "author": {
-        "name": "JacobPEvans"
-      }
-    },
     {
       "name": "ai-delegation",
       "source": "./ai-delegation",
       "description": "Delegate tasks to AI models, orchestrate premium-model work, and run autonomous maintenance loops",
-      "version": "4.21.0",
-      "author": {
-        "name": "JacobPEvans"
-      }
-    },
-    {
-      "name": "config-management",
-      "source": "./config-management",
-      "description": "Sync AI tool permissions across repos and quickly add always-allow permissions",
-      "version": "4.21.0",
-      "author": {
-        "name": "JacobPEvans"
-      }
-    },
-    {
-      "name": "codeql-resolver",
-      "source": "./codeql-resolver",
-      "description": "Systematic CodeQL alert analysis and resolution for GitHub Actions workflows",
-      "version": "4.21.0",
-      "author": {
-        "name": "JacobPEvans"
-      }
-    },
-    {
-      "name": "process-cleanup",
-      "source": "./process-cleanup",
-      "description": "Cleanup orphaned MCP server processes on session exit — workaround for upstream bug #1935",
-      "version": "4.21.0",
-      "author": {
-        "name": "JacobPEvans"
-      }
-    },
-    {
-      "name": "pr-lifecycle",
-      "source": "./pr-lifecycle",
-      "description": "Automatically triggers PR finalization after PR creation",
-      "version": "4.21.0",
-      "author": {
-        "name": "JacobPEvans"
-      }
-    },
-    {
-      "name": "git-standards",
-      "source": "./git-standards",
-      "description": "Git workflow standards, branch hygiene, PR creation guards, and issue linking",
-      "version": "4.21.0",
+      "version": "4.19.0",
       "author": {
         "name": "JacobPEvans"
       }
@@ -112,43 +22,70 @@
       "name": "code-standards",
       "source": "./code-standards",
       "description": "Code quality standards, documentation formatting, testing philosophy, and review guidelines",
-      "version": "4.21.0",
+      "version": "4.19.0",
       "author": {
         "name": "JacobPEvans"
       }
     },
     {
-      "name": "infra-standards",
-      "source": "./infra-standards",
-      "description": "Infrastructure standards for Proxmox, Terraform, Ansible including deployment pipeline, IP addressing, and secrets management",
-      "version": "4.21.0",
+      "name": "codeql-resolver",
+      "source": "./codeql-resolver",
+      "description": "Systematic CodeQL alert analysis and resolution for GitHub Actions workflows",
+      "version": "4.19.0",
       "author": {
         "name": "JacobPEvans"
       }
     },
     {
-      "name": "project-standards",
-      "source": "./project-standards",
-      "description": "AgentsMD authoring standards, workspace management, and skills/tools registry lookup",
-      "version": "4.21.0",
+      "name": "config-management",
+      "source": "./config-management",
+      "description": "Sync AI tool permissions across repos and quickly add always-allow permissions",
+      "version": "4.19.0",
       "author": {
         "name": "JacobPEvans"
       }
     },
     {
-      "name": "session-analytics",
-      "source": "./session-analytics",
-      "description": "Claude Code session token analytics via Splunk OTEL telemetry",
-      "version": "4.21.0",
+      "name": "content-guards",
+      "source": "./content-guards",
+      "description": "Combined content validation and guard plugin that merges token-validator, markdown-validator, webfetch-guard, and issue-limiter functionality",
+      "version": "4.19.0",
       "author": {
         "name": "JacobPEvans"
       }
     },
     {
-      "name": "pal-health",
-      "source": "./pal-health",
-      "description": "Session-start hook to warn about recent PAL MCP Doppler failures",
-      "version": "4.21.0",
+      "name": "git-guards",
+      "source": "./git-guards",
+      "description": "Combined git security and workflow protection via PreToolUse hooks - merges git-permission-guard and main-branch-guard functionality",
+      "version": "4.19.0",
+      "author": {
+        "name": "JacobPEvans"
+      }
+    },
+    {
+      "name": "git-standards",
+      "source": "./git-standards",
+      "description": "Git workflow standards, branch hygiene, PR creation guards, and issue linking",
+      "version": "4.19.0",
+      "author": {
+        "name": "JacobPEvans"
+      }
+    },
+    {
+      "name": "git-workflows",
+      "source": "./git-workflows",
+      "description": "Git worktree initialization, main branch sync, repository refresh, and troubleshooting workflows",
+      "version": "4.19.0",
+      "author": {
+        "name": "JacobPEvans"
+      }
+    },
+    {
+      "name": "github-workflows",
+      "source": "./github-workflows",
+      "description": "PR management, multi-repo PR finalization, and issue shaping with Shape Up methodology",
+      "version": "4.19.0",
       "author": {
         "name": "JacobPEvans"
       }
@@ -157,7 +94,70 @@
       "name": "homelab-ops",
       "source": "./homelab-ops",
       "description": "High-level operational runbooks for homelab management: DR-node power management, DNS ingress convergence, and secrets-engine identity bring-up",
-      "version": "4.21.0",
+      "version": "4.19.0",
+      "author": {
+        "name": "JacobPEvans"
+      }
+    },
+    {
+      "name": "infra-orchestration",
+      "source": "./infra-orchestration",
+      "description": "Cross-repo infrastructure orchestration for Terraform and Ansible workflows",
+      "version": "4.19.0",
+      "author": {
+        "name": "JacobPEvans"
+      }
+    },
+    {
+      "name": "infra-standards",
+      "source": "./infra-standards",
+      "description": "Infrastructure standards for Proxmox, Terraform, Ansible including deployment pipeline, IP addressing, and secrets management",
+      "version": "4.19.0",
+      "author": {
+        "name": "JacobPEvans"
+      }
+    },
+    {
+      "name": "openbao",
+      "source": "./openbao",
+      "description": "OpenBao-backed secrets access model: mint ephemeral credentials from secrets engines instead of storing static ones; reads pre-authorized, writes human-gated",
+      "version": "4.19.0",
+      "author": {
+        "name": "JacobPEvans"
+      }
+    },
+    {
+      "name": "pal-health",
+      "source": "./pal-health",
+      "description": "Session-start hook to warn about recent PAL MCP Doppler failures",
+      "version": "4.19.0",
+      "author": {
+        "name": "JacobPEvans"
+      }
+    },
+    {
+      "name": "pr-lifecycle",
+      "source": "./pr-lifecycle",
+      "description": "Automatically triggers PR finalization after PR creation",
+      "version": "4.19.0",
+      "author": {
+        "name": "JacobPEvans"
+      }
+    },
+    {
+      "name": "process-cleanup",
+      "source": "./process-cleanup",
+      "description": "Cleanup orphaned MCP server processes on session exit \u2014 workaround for upstream bug #1935",
+      "version": "4.19.0",
+      "author": {
+        "name": "JacobPEvans"
+      }
+    },
+    {
+      "name": "project-standards",
+      "source": "./project-standards",
+      "description": "AgentsMD authoring standards, workspace management, and skills/tools registry lookup",
+      "version": "4.19.0",
       "author": {
         "name": "JacobPEvans"
       }
@@ -166,7 +166,16 @@
       "name": "script-guards",
       "source": "./script-guards",
       "description": "Prevents unnecessary script generation - enforces research-first, native-tool-first patterns via PreToolUse and UserPromptSubmit hooks",
-      "version": "4.21.0",
+      "version": "4.19.0",
+      "author": {
+        "name": "JacobPEvans"
+      }
+    },
+    {
+      "name": "session-analytics",
+      "source": "./session-analytics",
+      "description": "Claude Code session token analytics via Splunk OTEL telemetry",
+      "version": "4.19.0",
       "author": {
         "name": "JacobPEvans"
       }

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -6,14 +6,14 @@
   },
   "metadata": {
     "description": "Claude Code plugins and hooks by JacobPEvans",
-    "version": "4.19.0"
+    "version": "4.21.0"
   },
   "plugins": [
     {
       "name": "ai-delegation",
       "source": "./ai-delegation",
       "description": "Delegate tasks to AI models, orchestrate premium-model work, and run autonomous maintenance loops",
-      "version": "4.19.0",
+      "version": "4.21.0",
       "author": {
         "name": "JacobPEvans"
       }
@@ -22,7 +22,7 @@
       "name": "code-standards",
       "source": "./code-standards",
       "description": "Code quality standards, documentation formatting, testing philosophy, and review guidelines",
-      "version": "4.19.0",
+      "version": "4.21.0",
       "author": {
         "name": "JacobPEvans"
       }
@@ -31,7 +31,7 @@
       "name": "codeql-resolver",
       "source": "./codeql-resolver",
       "description": "Systematic CodeQL alert analysis and resolution for GitHub Actions workflows",
-      "version": "4.19.0",
+      "version": "4.21.0",
       "author": {
         "name": "JacobPEvans"
       }
@@ -40,7 +40,7 @@
       "name": "config-management",
       "source": "./config-management",
       "description": "Sync AI tool permissions across repos and quickly add always-allow permissions",
-      "version": "4.19.0",
+      "version": "4.21.0",
       "author": {
         "name": "JacobPEvans"
       }
@@ -49,7 +49,7 @@
       "name": "content-guards",
       "source": "./content-guards",
       "description": "Combined content validation and guard plugin that merges token-validator, markdown-validator, webfetch-guard, and issue-limiter functionality",
-      "version": "4.19.0",
+      "version": "4.21.0",
       "author": {
         "name": "JacobPEvans"
       }
@@ -58,7 +58,7 @@
       "name": "git-guards",
       "source": "./git-guards",
       "description": "Combined git security and workflow protection via PreToolUse hooks - merges git-permission-guard and main-branch-guard functionality",
-      "version": "4.19.0",
+      "version": "4.21.0",
       "author": {
         "name": "JacobPEvans"
       }
@@ -67,7 +67,7 @@
       "name": "git-standards",
       "source": "./git-standards",
       "description": "Git workflow standards, branch hygiene, PR creation guards, and issue linking",
-      "version": "4.19.0",
+      "version": "4.21.0",
       "author": {
         "name": "JacobPEvans"
       }
@@ -76,7 +76,7 @@
       "name": "git-workflows",
       "source": "./git-workflows",
       "description": "Git worktree initialization, main branch sync, repository refresh, and troubleshooting workflows",
-      "version": "4.19.0",
+      "version": "4.21.0",
       "author": {
         "name": "JacobPEvans"
       }
@@ -85,7 +85,7 @@
       "name": "github-workflows",
       "source": "./github-workflows",
       "description": "PR management, multi-repo PR finalization, and issue shaping with Shape Up methodology",
-      "version": "4.19.0",
+      "version": "4.21.0",
       "author": {
         "name": "JacobPEvans"
       }
@@ -94,7 +94,7 @@
       "name": "homelab-ops",
       "source": "./homelab-ops",
       "description": "High-level operational runbooks for homelab management: DR-node power management, DNS ingress convergence, and secrets-engine identity bring-up",
-      "version": "4.19.0",
+      "version": "4.21.0",
       "author": {
         "name": "JacobPEvans"
       }
@@ -103,7 +103,7 @@
       "name": "infra-orchestration",
       "source": "./infra-orchestration",
       "description": "Cross-repo infrastructure orchestration for Terraform and Ansible workflows",
-      "version": "4.19.0",
+      "version": "4.21.0",
       "author": {
         "name": "JacobPEvans"
       }
@@ -112,7 +112,7 @@
       "name": "infra-standards",
       "source": "./infra-standards",
       "description": "Infrastructure standards for Proxmox, Terraform, Ansible including deployment pipeline, IP addressing, and secrets management",
-      "version": "4.19.0",
+      "version": "4.21.0",
       "author": {
         "name": "JacobPEvans"
       }
@@ -121,7 +121,7 @@
       "name": "openbao",
       "source": "./openbao",
       "description": "OpenBao-backed secrets access model: mint ephemeral credentials from secrets engines instead of storing static ones; reads pre-authorized, writes human-gated",
-      "version": "4.19.0",
+      "version": "4.21.0",
       "author": {
         "name": "JacobPEvans"
       }
@@ -130,7 +130,7 @@
       "name": "pal-health",
       "source": "./pal-health",
       "description": "Session-start hook to warn about recent PAL MCP Doppler failures",
-      "version": "4.19.0",
+      "version": "4.21.0",
       "author": {
         "name": "JacobPEvans"
       }
@@ -139,7 +139,7 @@
       "name": "pr-lifecycle",
       "source": "./pr-lifecycle",
       "description": "Automatically triggers PR finalization after PR creation",
-      "version": "4.19.0",
+      "version": "4.21.0",
       "author": {
         "name": "JacobPEvans"
       }
@@ -148,7 +148,7 @@
       "name": "process-cleanup",
       "source": "./process-cleanup",
       "description": "Cleanup orphaned MCP server processes on session exit \u2014 workaround for upstream bug #1935",
-      "version": "4.19.0",
+      "version": "4.21.0",
       "author": {
         "name": "JacobPEvans"
       }
@@ -157,7 +157,7 @@
       "name": "project-standards",
       "source": "./project-standards",
       "description": "AgentsMD authoring standards, workspace management, and skills/tools registry lookup",
-      "version": "4.19.0",
+      "version": "4.21.0",
       "author": {
         "name": "JacobPEvans"
       }
@@ -166,7 +166,7 @@
       "name": "script-guards",
       "source": "./script-guards",
       "description": "Prevents unnecessary script generation - enforces research-first, native-tool-first patterns via PreToolUse and UserPromptSubmit hooks",
-      "version": "4.19.0",
+      "version": "4.21.0",
       "author": {
         "name": "JacobPEvans"
       }
@@ -175,7 +175,7 @@
       "name": "session-analytics",
       "source": "./session-analytics",
       "description": "Claude Code session token analytics via Splunk OTEL telemetry",
-      "version": "4.19.0",
+      "version": "4.21.0",
       "author": {
         "name": "JacobPEvans"
       }

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -21,6 +21,7 @@ This is a **Claude Code plugins repository** containing production-ready hooks f
 | **code-standards** | Skill | `/code-quality-standards`, `/review-standards` | Code quality standards, documentation formatting, testing philosophy, and review guidelines |
 | **git-standards** | Skill | `/git-workflow-standards`, `/pr-standards` | Git workflow standards, branch hygiene, PR creation guards, workaround vs fix classification, and issue linking |
 | **infra-standards** | Skill | `/infrastructure-standards` | Infrastructure standards for Proxmox, Terraform, Ansible including deployment pipeline and secrets management |
+| **openbao** | Skill | `/openbao-secrets` | OpenBao secrets access model: mint ephemeral credentials from engines instead of storing static ones; reads pre-authorized, writes human-gated |
 | **pal-health** | SessionStart | — | Warns on session start if PAL MCP had a recent Doppler auth failure |
 | **pr-lifecycle** | PostToolUse | Bash | Automatically triggers `/finalize-pr` after `gh pr create` succeeds |
 | **process-cleanup** | PostToolUse | — | Cleanup orphaned MCP server processes on session exit |

--- a/openbao/.claude-plugin/plugin.json
+++ b/openbao/.claude-plugin/plugin.json
@@ -1,0 +1,21 @@
+{
+  "name": "openbao",
+  "version": "4.19.0",
+  "description": "OpenBao-backed secrets access model: mint ephemeral credentials from secrets engines instead of storing static ones, read with the pre-authorized tier, and route write/apply through a human-gated wrapped single-use secret_id",
+  "author": {
+    "name": "JacobPEvans"
+  },
+  "license": "Apache-2.0",
+  "repository": "https://github.com/JacobPEvans/claude-code-plugins",
+  "keywords": [
+    "openbao",
+    "secrets",
+    "vault",
+    "approle",
+    "ephemeral-credentials",
+    "least-privilege"
+  ],
+  "skills": [
+    "./skills/openbao-secrets"
+  ]
+}

--- a/openbao/.claude-plugin/plugin.json
+++ b/openbao/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "openbao",
-  "version": "4.19.0",
+  "version": "4.21.0",
   "description": "OpenBao-backed secrets access model: mint ephemeral credentials from secrets engines instead of storing static ones, read with the pre-authorized tier, and route write/apply through a human-gated wrapped single-use secret_id",
   "author": {
     "name": "JacobPEvans"

--- a/openbao/README.md
+++ b/openbao/README.md
@@ -1,0 +1,50 @@
+# openbao
+
+The OpenBao-backed secrets access model as a Claude Code skill: **mint, don't
+store**, and **reading is pre-authorized, writing is gated**.
+
+Most credential mistakes are not "the token leaked" — they are "a standing token
+existed at all." This plugin encodes the alternative: obtain a short-lived
+credential from a secrets engine at the moment of use, and treat writing a secret
+as a human-approved act rather than an ambient capability.
+
+## What it covers
+
+- **Engine over storage** — if an engine can mint it (GitHub App installation
+  tokens, AWS STS), that engine is the only correct source. KV is reserved for
+  values nothing can mint.
+- **Store tiers** — which of the four tiers owns a given secret, and the
+  generate-at-source / promote-later rule.
+- **Read vs write** — reads run on an ambient, pre-authorized secret-zero; writes
+  and applies require a response-wrapped, single-use `secret_id` that a human
+  generates for that one operation. The wrap step *is* the checkpoint.
+- **Capability check** — confirm the exact path before converging a publisher.
+- **Handling rules** — never echo a token, never `curl -v`, fetch once and reuse
+  the variable, never dump the environment, no secret values in any artifact.
+
+The skill is deliberately environment-agnostic. Which engines are configured,
+mount paths, role names, and runbooks belong in your own operations docs — this
+plugin is the model, not the inventory.
+
+## Installation
+
+```bash
+claude plugins add jacobpevans-cc-plugins/openbao
+```
+
+## Usage
+
+No manual invocation required in most cases — the skill triggers when a task
+involves obtaining or handling a credential. Invoke it explicitly with:
+
+```text
+/openbao-secrets
+```
+
+Reach for it before fetching any credential, wiring a service to a secret,
+converging something that writes a secret, or whenever you are unsure whether a
+credential may simply be taken.
+
+## License
+
+Apache-2.0

--- a/openbao/skills/openbao-secrets/SKILL.md
+++ b/openbao/skills/openbao-secrets/SKILL.md
@@ -1,0 +1,99 @@
+---
+name: openbao-secrets
+description: "How to obtain and handle secrets under an OpenBao-backed access model: pick the right store tier, prefer engine-minted ephemeral credentials over static secrets, read with the pre-authorized tier, and route write/apply through the human-gated wrapped single-use secret_id. Use before fetching any credential, wiring a service to a secret, converging a publisher, or when tempted to paste a token — and whenever a task needs a credential and you are unsure whether you may just take it."
+---
+
+# OpenBao Secrets Access
+
+How to get a credential without creating a standing one, and how to handle it once
+you have it. Two rules carry most of the weight: **mint, don't store**, and
+**reading is pre-authorized, writing is gated**.
+
+> **State warning**: which engines are configured differs per environment and
+> changes over time. Verify capability before relying on it (below) — never assume
+> an engine is live because a config flag says enabled. A default is not a running
+> system.
+
+## Step 1: Does this credential need to exist at all?
+
+If a secrets **engine** can mint the credential, that engine is the only correct
+source. An engine-minted credential is short-lived, attributable to the run that
+asked for it, revocable by lease, and cannot leak durably. A static credential is
+the opposite on all four counts.
+
+| Need | Correct source | Never |
+| --- | --- | --- |
+| A GitHub token | `github/token/<permission_set>` (App installation token) | a stored PAT |
+| AWS credentials | `aws/sts/<role>` | a static access key |
+| Anything else an engine covers | that engine | a KV copy of it |
+| A value nothing can mint (third-party API key, app config, bootstrap material) | KV — that is KV's whole job | — |
+
+**If the engine for a resource is not configured in this environment, that need is
+blocked — it is not a licence to seed a static secret.** "The engine isn't ready
+yet" is precisely the moment the violation happens. Surface the gap; do not route
+around it.
+
+## Step 2: Pick the store tier
+
+Match the secret to the tier that owns it, then stop — one secret, one home:
+
+- **At-rest in-repo, encrypted** — for values a repo must carry (SOPS + age).
+- **Runtime injection** — ambient environment for a process (a secrets manager
+  run-wrapper). This is how a workload receives its bootstrap.
+- **Central secrets store (OpenBao)** — the source of truth for shared/service
+  credentials, and the only place engines mint from.
+- **Human vault** — credentials only a person uses interactively.
+
+**Generate at the source; promote later.** A new credential is generated (random,
+idempotent, generate-if-absent) at the least-shared tier where it is first used.
+It is promoted to the shared store only once a *second* consumer genuinely needs
+it — never seeded there "just in case."
+
+## Step 3: Authenticate — read vs write
+
+The access model splits on intent, and the split is the security boundary:
+
+| Intent | Secret-zero | Gate |
+| --- | --- | --- |
+| **Read** (fetch a secret, mint from an engine you are entitled to) | ambient — injected into the environment by the run-wrapper | **none — reading is pre-authorized** |
+| **Write / apply** (write a secret, converge a publisher, elevated mint) | a **response-wrapped, single-use `secret_id`** a human generates for this one operation | **the wrap step IS the human checkpoint** |
+
+So: reads are frictionless by design. Writes are not, and the friction is the
+point — a human wrapping one single-use `secret_id` is the approval. Never try to
+obtain a standing elevated credential to skip that step; that converts a gated
+action into an ambient one.
+
+## Step 4: Verify capability before you act
+
+Before converging anything that *writes* a secret, confirm you actually hold the
+capability on the exact path — do not discover it from a half-applied converge:
+
+```bash
+bao write sys/capabilities-self paths=<the/exact/path>
+```
+
+Check the path you will really write, not its parent. A converge that fails
+halfway through a publisher is worse than one that never started.
+
+## Handling rules (non-negotiable)
+
+- **Never echo a token.** Capture to a shell variable and reuse it. No `echo`, no
+  writing it to a file, no `.env`, no temp file.
+- **Never `curl -v`** with a token — verbose mode bleeds the header into the
+  transcript. Use `curl -sSL` (`-sS` shows real errors; `-L` follows HA redirects).
+- **Fetch once per session, reuse the variable.** Every fetch can cost an
+  interactive prompt or a lease.
+- **Never dump the environment** (`env`, `printenv`) — even filtered. Test one
+  variable: `[[ -n "$VAR" ]]`.
+- **No secret value in any transcript, commit, PR, issue, or doc.** Reference
+  where a value lives, never the value. Describe a scrub by category, never as a
+  real-value → placeholder mapping.
+- **Never hand-type a credential into a shared store.** See generate-at-source.
+
+## Related
+
+- **native-first** (script-guards) — the discovery ladder; use it before building
+  any bespoke credential plumbing.
+- Environment-specific detail (which engines are live, mount paths, role names,
+  runbooks) belongs in your own operations docs, not here — this skill is the
+  model, not the inventory.

--- a/openbao/skills/openbao-secrets/SKILL.md
+++ b/openbao/skills/openbao-secrets/SKILL.md
@@ -69,7 +69,7 @@ Before converging anything that *writes* a secret, confirm you actually hold the
 capability on the exact path — do not discover it from a half-applied converge:
 
 ```bash
-bao write sys/capabilities-self paths=<the/exact/path>
+bao write sys/capabilities-self paths="the/exact/path"
 ```
 
 Check the path you will really write, not its parent. A converge that fails


### PR DESCRIPTION
## Why

The last of the nine mined skills, and one the user explicitly asked for. Secrets handling is too org-specific to fold into a shared plugin, so this is a new `openbao` plugin carrying a single skill.

## What

The skill encodes the OpenBao access model. Two rules carry most of it: **mint, don't store**, and **reading is pre-authorized, writing is gated**.

- **Engine over storage** — if an engine can mint it (GitHub App tokens, AWS STS), that engine is the only correct source; KV is only for values nothing can mint.
- **Store-tier selection** + generate-at-source / promote-later.
- **Read vs write** — reads run on an ambient pre-authorized secret-zero; writes/applies need a human-generated, response-wrapped, single-use `secret_id`. The wrap step *is* the checkpoint.
- **Capability check** before converging a publisher.
- **Handling rules** — never echo a token, never `curl -v`, fetch once and reuse the var, never dump the environment, no secret values in any artifact.

## Scoping (public repo)

Deliberately capability-level and environment-agnostic — it names no endpoints, hosts, mounts, or roles, and it does **not** claim any engine is converged. The one line that mentions liveness is the *warning against* assuming it from a config default.

## Validation

- `plugin.json` + `marketplace.json` parse; registered in the CLAUDE.md/AGENTS.md table.
- markdownlint: 0 errors; description 485 chars.
- **A9 gate:** `grep -riE 'find-generic-password|keychain|GH_PAT_' openbao/` → **0**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RC6muwSosdFeLz3iBEJp57