### PR TITLE
chore(docs): drop unnecessary braces from $GIT_HOME_PUBLIC ref

### DIFF
--- a/infra-orchestration/skills/sync-inventory/SKILL.md
+++ b/infra-orchestration/skills/sync-inventory/SKILL.md
@@ -43,7 +43,7 @@ was not crossed — run a real apply (next step). Reference docs:
 The only way to republish is the publish boundary itself:
 
 ```bash
-cd ${GIT_HOME_PUBLIC}/homelab/tofu-proxmox/main
+cd $GIT_HOME_PUBLIC/homelab/tofu-proxmox/main
 tofu apply
 ```
 


### PR DESCRIPTION
Bare `$GIT_HOME_PUBLIC` is valid standard bash here — the next character is a path separator, so the name terminates on its own and the braces add nothing.

Braces are kept wherever removing them would change meaning (`${VAR}_suffix`, `${VAR:-default}`); this repo had no such case.

Part of a workspace-wide convention cleanup.

🤖 Generated with [Claude Code](https://claude.com/claude-code)