### PR TITLE
chore: inherit Codex workflow credentials

### DIFF
--- a/.github/workflows/ai-all.yml
+++ b/.github/workflows/ai-all.yml
@@ -54,7 +54,7 @@ jobs:
       id-token: write
       issues: write
       pull-requests: write
-    uses: dryvist/ai-workflows/.github/workflows/suite-all.yml@v0.31
+    uses: dryvist/ai-workflows/.github/workflows/suite-all.yml@main
     with:
       caller_event: ${{ github.event_name }}
       review_prompt: "Focus on Claude Code plugin structure, skill authoring patterns, and hook configuration best practices"

--- a/.github/workflows/ai-ci.yml
+++ b/.github/workflows/ai-ci.yml
@@ -23,7 +23,7 @@ permissions:
 
 jobs:
   ci-suite:
-    uses: dryvist/ai-workflows/.github/workflows/suite-ci.yml@v0.31
+    uses: dryvist/ai-workflows/.github/workflows/suite-ci.yml@main
     with:
       repo_context: "Claude Code plugins: skills, hooks, and slash commands for Claude Code CLI"
       ci_structure: "validate-plugin.yml (JSON schema validation for plugin manifests)"

--- a/.github/workflows/ai-pr-care.yml
+++ b/.github/workflows/ai-pr-care.yml
@@ -26,6 +26,7 @@ jobs:
     uses: dryvist/ai-workflows/.github/workflows/cc-dep-review.yml@main
     secrets:
       GH_ACTION_AI_API_KEY: ${{ secrets.GH_ACTION_AI_API_KEY }}
+      OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
 
   release-notes:
     permissions:
@@ -35,3 +36,4 @@ jobs:
     uses: dryvist/ai-workflows/.github/workflows/cc-release-notes.yml@main
     secrets:
       GH_ACTION_AI_API_KEY: ${{ secrets.GH_ACTION_AI_API_KEY }}
+      OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}

--- a/.github/workflows/best-practices.yml
+++ b/.github/workflows/best-practices.yml
@@ -19,5 +19,5 @@ concurrency:
 
 jobs:
   best-practices:
-    uses: dryvist/ai-workflows/.github/workflows/best-practices.yml@v0.31
+    uses: dryvist/ai-workflows/.github/workflows/best-practices.yml@main
     secrets: inherit

--- a/.github/workflows/code-simplifier.yml
+++ b/.github/workflows/code-simplifier.yml
@@ -16,5 +16,5 @@ concurrency:
 
 jobs:
   simplify:
-    uses: dryvist/ai-workflows/.github/workflows/cc-code-simplifier.yml@v0.31
+    uses: dryvist/ai-workflows/.github/workflows/cc-code-simplifier.yml@main
     secrets: inherit

--- a/.github/workflows/issue-auto-resolve.yml
+++ b/.github/workflows/issue-auto-resolve.yml
@@ -72,7 +72,7 @@ jobs:
       id-token: write
       issues: write
       pull-requests: write
-    uses: dryvist/ai-workflows/.github/workflows/issue-triage.yml@v0.31
+    uses: dryvist/ai-workflows/.github/workflows/issue-triage.yml@main
     secrets: inherit
     with:
       issue_number: ${{ inputs.issue_number }}
@@ -89,7 +89,7 @@ jobs:
       id-token: write
       issues: write
       pull-requests: write
-    uses: dryvist/ai-workflows/.github/workflows/cc-issue-resolver.yml@v0.31
+    uses: dryvist/ai-workflows/.github/workflows/cc-issue-resolver.yml@main
     secrets: inherit
     with:
       repo_context: "Claude Code plugins: skills, hooks, and slash commands for Claude Code CLI"

--- a/.github/workflows/issue-hygiene.yml
+++ b/.github/workflows/issue-hygiene.yml
@@ -12,5 +12,5 @@ permissions:
   pull-requests: read
 jobs:
   hygiene:
-    uses: dryvist/ai-workflows/.github/workflows/issue-hygiene.yml@v0.31
+    uses: dryvist/ai-workflows/.github/workflows/issue-hygiene.yml@main
     secrets: inherit

--- a/.github/workflows/issue-sweeper.yml
+++ b/.github/workflows/issue-sweeper.yml
@@ -12,5 +12,5 @@ permissions:
   pull-requests: read
 jobs:
   sweep:
-    uses: dryvist/ai-workflows/.github/workflows/issue-sweeper.yml@v0.31
+    uses: dryvist/ai-workflows/.github/workflows/issue-sweeper.yml@main
     secrets: inherit

--- a/.github/workflows/next-steps.yml
+++ b/.github/workflows/next-steps.yml
@@ -17,5 +17,5 @@ concurrency:
 
 jobs:
   next-steps:
-    uses: dryvist/ai-workflows/.github/workflows/cc-next-steps.yml@v0.31
+    uses: dryvist/ai-workflows/.github/workflows/cc-next-steps.yml@main
     secrets: inherit


### PR DESCRIPTION
## Summary

Adopt the provider-neutral inherited AI workflow contract across the plugin repository.

## Changes

- Forward `OPENAI_API_KEY` from explicit reusable-workflow callers.
- Migrate nine stale `ai-workflows@v0.31` references to the documented `@main` channel.
- Keep Claude as the default while allowing organization-level Codex selection.

## Test Plan

- Validate all modified workflows with `actionlint`.
- Confirm plugin validation, CI gates, zizmor, and CodeQL pass.

Refs: dryvist/ai-workflows#352