### PR TITLE
feat(git-workflows): recognize Zammad as the incident-tracking system

### DIFF
--- a/docs/LABELS.md
+++ b/docs/LABELS.md
@@ -59,6 +59,11 @@ Unlike issues, PR labels are applied manually by the author or reviewers.
 
 **Note**: Type labels align with [Conventional Commits](https://www.conventionalcommits.org/) and semantic versioning to automate release management.
 
+**Scope note**: `type:bug` covers code/repo defects — something in a
+repository's code or config is broken. Operational incidents (production or
+infrastructure anomalies, RCAs, postmortem-worthy events) are tracked as
+Zammad tickets, not GitHub issues, and carry no `type:*` label.
+
 ### Priority Labels (`priority:*`)
 
 **Purpose**: Indicates urgency and helps with work prioritization and sprint planning.

--- a/git-standards/skills/pr-standards/SKILL.md
+++ b/git-standards/skills/pr-standards/SKILL.md
@@ -41,6 +41,9 @@ gh issue list --repo JacobPEvans/<repo> --state open --search "<keywords>"
 
 Include `Closes #X` or `Related to #X` in PR body. After creation:
 `gh issue comment <num> --body "Implementation: #<pr>"`.
+This guard only searches GitHub issues — code/repo defects. If the PR resolves
+an operational incident, reference the Zammad ticket in prose instead (see
+Issue-PR Bidirectional Linking below).
 
 **Guard 4 — Validate branch has commits**:
 
@@ -127,6 +130,11 @@ Closes #X
 Use `Closes #X` for full resolution (auto-closes on merge).
 Use `Related to #X` for partial.
 
+If the PR also resolves an operational incident, add a `Zammad: <full ticket
+URL>` line alongside `Closes #X`. GitHub's auto-close syntax does not reach
+Zammad — update the ticket separately (`zammad_update_ticket` when that MCP
+tool is available, otherwise a manual note).
+
 ## AI Mention Policy
 
 **NEVER tag AI assistants in PR comments** unless explicitly requesting
@@ -146,6 +154,13 @@ only — PR descriptions and release notes are plain prose. Applies to all
 PRs — human, AI-assisted, and bot-authored automated fixes.
 
 ## GitHub Issue Standards
+
+GitHub Issues track code, config, and repo defects/features — the fix lives in
+a repository. Operational incidents (production/infrastructure anomalies,
+RCAs, postmortems, runbook-worthy events) are not GitHub issues — they are
+Zammad tickets (`#NNNNN`, the org's incident system of record). If what you're
+filing describes something that broke or degraded in production rather than a
+defect in this repo, it belongs in Zammad instead.
 
 ### Title Prefixes
 

--- a/git-workflows/ARCHITECTURE.md
+++ b/git-workflows/ARCHITECTURE.md
@@ -63,7 +63,7 @@ flowchart LR
         clean_gone["/clean_gone"]:::external
     end
 
-    subgraph builtin["AI analysis + gh issue list"]
+    subgraph builtin["AI analysis + gh issue list + Zammad tickets"]
         follow_up["Follow-up prompt\ngeneration"]:::ai
     end
 

--- a/git-workflows/skills/handoff/SKILL.md
+++ b/git-workflows/skills/handoff/SKILL.md
@@ -35,6 +35,11 @@ Do not trust memory. Collect, at minimum:
 - `git status`, current branch, and any worktree paths the work lives in.
 - Open PRs/issues for the work: `gh pr list` / `gh issue list`. Capture **full
   URLs**, never bare `#123`.
+- Open Zammad tickets for the work, if any: if `mcp__zammad__*` tools are
+  available this session, check with `zammad_search_tickets`; otherwise rely on
+  ticket numbers already known from context. Capture **full ticket URLs**
+  (`$ZAMMAD_URL/#ticket/zoom/<id>`), never a bare `#17053` — same rule as
+  GitHub, extended to Zammad.
 - The one or two files a fresh session must read first to be dangerous.
 
 ## Step 2: Write the goal statement (HARD CAP < 4000 chars)
@@ -96,7 +101,7 @@ Rules:
   values when re-seeding; no secret values in any transcript or PR" is a rule.
 - **Restate the goal; never say "continue."** The new session has no memory. Never
   write "continue what you were doing" or "as discussed above."
-- Full URLs for every PR/issue. Absolute paths for every file and cwd.
+- Full URLs for every PR/issue/Zammad ticket. Absolute paths for every file and cwd.
 
 ## Step 4: Emit
 

--- a/git-workflows/skills/session-status/SKILL.md
+++ b/git-workflows/skills/session-status/SKILL.md
@@ -167,13 +167,26 @@ Perform git and GitHub checks to locate active changes and remote state:
 
 ## Step 4: Triage and Recommendations
 
-Split the gathered items into two buckets:
+Split the gathered items into three buckets:
 
 1. **Next-session prompt** — items small enough to complete in a single focused
    session (roughly 1–3 tasks). Combine related items where possible.
-2. **GitHub issues** — everything else. Before recommending new issues, search
-   existing open issues with `gh issue list --state open --json number,title,url`
-   for duplicates. Use full URLs for references.
+2. **GitHub issues** — code, config, or repo defects and features: something in
+   a repository has to change. Before recommending new issues, search existing
+   open issues with `gh issue list --state open --json number,title,url` for
+   duplicates. Use full URLs for references.
+3. **Zammad tickets** — operational/incident-shaped items: a production or
+   infrastructure anomaly, an RCA- or postmortem-worthy event, or something a
+   runbook should have caught. Zammad is the org's incident system of record;
+   these do not become GitHub issues. If the `mcp__zammad__*` tools are
+   available this session, search for duplicates first with
+   `zammad_search_tickets` — same shape as the `gh issue list` dedup check
+   above. If those tools are not configured this session, skip the dedup check
+   and say so explicitly; never guess a ticket number or state.
+
+An item that is both (e.g. a bug that caused an outage) gets split: a Zammad
+ticket for the incident, a GitHub issue for the underlying code fix, each
+referencing the other.
 
 ---
 
@@ -223,8 +236,29 @@ Recommended GitHub Issues:
 ─────────────────────────────────────
 1. <Title> — <one-line summary> [new | update <issue-url>]
 ─────────────────────────────────────
+
+Recommended Zammad Tickets:
+─────────────────────────────────────
+1. <Title> — <one-line summary> [new | update <Zammad ticket URL> | dedup not
+   checked — Zammad MCP unavailable this session]
+─────────────────────────────────────
 ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 ```
+
+If every item in the "Unfinished Work & Future Tasks" section above is already
+a tracked Zammad ticket, write the heading as
+`Unfinished Work & Future Tasks (tracked in Zammad, not GitHub):` and prefix
+each item with its bare ticket number, matching this shape:
+
+```text
+Unfinished Work & Future Tasks (tracked in Zammad, not GitHub):
+  - #17053  <one-line description>
+  - #17058  <one-line description>
+```
+
+This is a live, human-facing report, not a cold-start artifact — a bare
+`#NNNNN` here is fine. The "always full URL, never bare `#123`" rule applies
+to `handoff` and `wrap-up`'s resume blocks, not this dashboard.
 
 ---
 

--- a/git-workflows/skills/wrap-up/SKILL.md
+++ b/git-workflows/skills/wrap-up/SKILL.md
@@ -79,8 +79,11 @@ Invoke `/clean_gone` to remove any local branches whose remote tracking branch h
 
 If `/session-status` in Step 0 surfaced follow-up work, invoke the `/handoff`
 skill to emit the next-session artifact. Pass it the "Recommended Prompt for Next
-Session", "Recommended GitHub Issues", and "Session Issues Log" sections from the
-Step 0 report as the source material.
+Session", "Recommended GitHub Issues", "Recommended Zammad Tickets", and
+"Session Issues Log" sections from the Step 0 report as the source material.
+Keep the two tracked-follow-up kinds distinct in the handoff — a GitHub issue is
+a code/repo fix, a Zammad ticket is operational/incident work — never relabel
+one as the other.
 
 `/handoff` produces the two-part artifact — a `## Goal statement` capped under
 4000 characters (measured with `wc -c`) plus an unbounded `## Full prompt` — so
@@ -228,7 +231,9 @@ worktree-removal command shape from `/troubleshoot-worktree` and aligns with
 - **refresh-repo** (github-workflows) — PR readiness check + repo sync +
   worktree cleanup (Path A Step A1 dependency); also provides `--sweep` and
   `--prune-stale` modes
-- **shape-issues** (github-workflows) — Shape and create well-structured GitHub issues
+- **shape-issues** (github-workflows) — Shape and create well-structured GitHub
+  issues for code/repo defects and features; not for incidents (Zammad, see
+  session-status Step 4 and pr-standards)
 - **troubleshoot-worktree** (git-workflows) — Worktree-removal command shape reused by `purge-pr` mode
 - **pr-standards** (git-standards) — Workaround Classification rubric used to decide when `purge-pr` is the right action
 - **git-flow-next** (git-workflows) — Dedicated git-flow-next guide, worktree setup, and promotion steps

--- a/github-workflows/skills/finalize-pr/SKILL.md
+++ b/github-workflows/skills/finalize-pr/SKILL.md
@@ -230,6 +230,11 @@ Steps 4.1 and 4.2 run sequentially within the agent. Step 4.3 runs after both.
 1. Extract keywords from branch name and commit messages.
 2. Search GitHub issues and PRs for related items (limit 5 each).
 3. Add `Closes #X` (directly related issues) or `Related: #X` (adjacent PRs) — no guessing.
+4. If the branch name, commits, or existing PR body already name a Zammad
+   ticket (`#NNNNN`, `Zammad #NNNNN`, or a `$ZAMMAD_URL/#ticket/zoom/<id>`
+   link), preserve it in the regenerated body as `Zammad: <full ticket URL>`.
+   Do not search Zammad for new matches here — only carry forward a reference
+   that already exists in this PR's own history.
 
 ### 4.3 Apply Updates
 


### PR DESCRIPTION
## Summary
- The `dryvist` org adopted Zammad as its incident system of record (live 2026-07-17), scoped to operational/infra incidents — separate from GitHub Issues, which stays scoped to code/repo defects and features.
- `session-status`, `wrap-up`, `handoff`, `pr-standards`, `finalize-pr`, and `LABELS.md` only knew about GitHub issues, so operational follow-ups had no correct home.
- Adds a Zammad ticket lane alongside the existing GitHub issue lane in each skill's triage/output. `session-status`'s dashboard format matches a real report format already in use, including graceful degradation when the `mcp__zammad__*` MCP tools aren't configured in a given session.
- Uses `$ZAMMAD_URL` throughout, never a literal hostname — this repo is public.

## Test plan
- [x] Reviewed diff manually against the approved plan; 7 files changed, no unrelated hits.
- [x] Grepped for literal `zammad.jacobpevans.com` — none found.
- [x] Content-guards markdown-validator hook ran clean on every edit (PostToolUse, no manual step).
- [ ] No functional/runtime surface to exercise — this is prose-only skill documentation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Txgeis2rdg3KgSDdCeAp7x