### PR TITLE
feat(ai-delegation): add orchestrator heartbeat + subagent waiter timeouts

### DIFF
--- a/ai-delegation/skills/premium-agent-orchestration/SKILL.md
+++ b/ai-delegation/skills/premium-agent-orchestration/SKILL.md
@@ -44,8 +44,6 @@ name. Resolve each tier against whatever models the current environment
 actually offers (native subagent model options, configured CLIs, local
 serving); never assume a specific vendor's lineup.
 
-Delegate work whose output can be verified from evidence.
-
 | Tier | Use for | Boundary |
 | --- | --- | --- |
 | Local/free | File discovery, log summaries, simple scans, checklist verification, cheap summaries | Report facts and evidence; avoid product or architecture calls |
@@ -145,6 +143,15 @@ must survive losing it:
   spawning is unavailable. Degrade to serial — never abort the mission or
   restart shared infrastructure that would kill the lead session mid-run.
 - On spawn failure, re-probe with backoff; do not retry-loop spawns.
+- Arm a recurring heartbeat (cron/monitor) re-invoking the lead every ~30 min
+  (your call, never over 50 min — the prompt-cache ceiling). Each firing:
+  check which executors owe reports, ground-truth-verify anything silent
+  >45 min (silence isn't progress — watchers die silently, e.g. credential
+  expiry), advance the critical path.
+- Every subagent waiter/poller needs a bounded timeout (~30 min default, your
+  call); on expiry it surfaces state to the lead instead of waiting longer.
+  Poll loops re-mint short-lived credentials per attempt, never held across
+  waits.
 
 See the `subagent-resilience` rule (ai-assistant-instructions) for the full
 contract.


### PR DESCRIPTION
Adds two watcher/timeout rules learned during an overnight autonomous mission, folded into the existing **Substrate Resilience** bullet list rather than a new section — it already covers surviving invisible spawn-substrate failure, and these two extend the same theme to *runtime* liveness:

1. **Orchestrator heartbeat** — the lead arms a recurring watcher (cron/monitor) that re-invokes itself every ~30 min (its own call, never over 50 min — the prompt-cache ceiling). Each firing checks which executors owe reports, ground-truth-verifies anything silent past 45 min (silence isn't progress — watchers die silently, e.g. credential expiry), and advances the critical path.
2. **Subagent waiter timeouts** — every waiter/poller a subagent arms carries a bounded timeout (~30 min default, its own call); on expiry it surfaces state to the lead instead of blocking longer. Poll loops re-mint short-lived credentials per attempt, never holding one across waits.

Also cut a near-duplicate sentence in Model Tiers that restated Purpose's delegate-by-evidence line, in the same pass.

No plugin version bump — this repo's version is release-please-managed (see `.release-please-manifest.json`); past skill-only edits (e.g. #393, #403) never hand-touched `plugin.json`.

**Token economy proof** (skill body, `ai-delegation/skills/premium-agent-orchestration/SKILL.md`):

| | Words | Chars | Approx tokens (chars/4) |
| --- | --- | --- | --- |
| Before | 1205 | 7975 | ~1993 |
| After | 1280 | 8493 | ~2123 |

Net +75 words / +518 chars / ~130 tokens for two new operational rules, after trimming one redundant sentence in the same pass.

Pre-commit clean: markdownlint, file-size, agent-skill validation, plugin frontmatter validation all pass.